### PR TITLE
new: CIツール(GitHub Actions)の設定をした

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,14 @@ jobs:
           - 3306:3306
         env:
           MYSQL_ROOT_PASSWORD: root
-        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 10
+          MYSQL_DATABASE: api_test
+          MYSQL_USER: user
+          MYSQL_PASSWORD: password
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=3
 
     steps:
       - name: Checkout code
@@ -47,7 +54,6 @@ jobs:
 
       - name: Bundler and gem install
         run: |
-          gem install bundler
           bundle config set path 'vendor/bundle'
           bundle install --jobs 4 --retry 3
 
@@ -86,7 +92,6 @@ jobs:
 
       - name: Bundler and gem install
         run: |
-          gem install bundler
           bundle config set path 'vendor/bundle'
           bundle install --jobs 4 --retry 3
 
@@ -102,6 +107,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
 
       - name: Cache node modules
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,118 @@
+# テスト(rspec)、コードルール(rubocop, eslint, prettier)のチェックを行う
+name: Continuous Integration
+
+# 当 workflow の実行タイミング
+# ブランチへの push 時
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# 当 workflow が行う処理
+jobs:
+  # 処理① rspec がオールグリーンであることをチェック
+  rspec:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: backend
+    services:
+      mysql:
+        image: mysql:8.4
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache bundler dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-bundler-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bundler-
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.1
+          bundler-cache: true
+
+      - name: Bundler and gem install
+        run: |
+          gem install bundler
+          bundle config set path 'vendor/bundle'
+          bundle install --jobs 4 --retry 3
+
+      - name: Database create and migrate
+        run: |
+          cp config/database.yml.ci config/database.yml
+          bundle exec rails db:create RAILS_ENV=test
+          bundle exec ridgepole --apply --file db/schemas/Schemafile --config config/database.yml --env test
+
+      - name: Run rspec
+        run: bundle exec bin/rspec
+
+  # 処理② rubocop のルール違反がないことをチェック
+  rubocop:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache bundler dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-bundler-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bundler-
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.1
+          bundler-cache: true
+
+      - name: Bundler and gem install
+        run: |
+          gem install bundler
+          bundle config set path 'vendor/bundle'
+          bundle install --jobs 4 --retry 3
+
+      - name: Run rubocop
+        run: bundle exec rubocop --server
+
+  # 処理③ eslint(& prettier) のルール違反がないことをチェック
+  eslint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend/app
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: frontend/app/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('frontend/app/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install packages
+        run: npm install
+
+      - name: Run lint
+        run: npm run lint

--- a/backend/config/database.yml.ci
+++ b/backend/config/database.yml.ci
@@ -2,8 +2,8 @@ default: &default
   adapter: mysql2
   encoding: utf8mb4
   pool: 5
-  username: root
-  password: root
+  username: user
+  password: password
   host: 127.0.0.1
   port: 3306
 test:

--- a/backend/config/database.yml.ci
+++ b/backend/config/database.yml.ci
@@ -1,0 +1,11 @@
+default: &default
+  adapter: mysql2
+  encoding: utf8mb4
+  pool: 5
+  username: root
+  password: root
+  host: 127.0.0.1
+  port: 3306
+test:
+  <<: *default
+  database: api_test


### PR DESCRIPTION
## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes #9 

## やったこと
<!-- このプルリクで何をしたのか？ -->
- GitHub Actionsで以下を実行するよう設定した
  - Rubocop
  - Rspec
  - Lintツール

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- なし

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- `act pull_request --container-architecture linux/amd64` の実行結果
```bash
tetsuya-shyline $ act pull_request --container-architecture linux/amd64
INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock' 
[Continuous Integration/eslint ] 🚀  Start image=catthehacker/ubuntu:act-latest
[Continuous Integration/rspec  ] 🚀  Start image=catthehacker/ubuntu:act-latest
[Continuous Integration/rubocop] 🚀  Start image=catthehacker/ubuntu:act-latest
[Continuous Integration/eslint ]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=true
[Continuous Integration/rubocop]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=true
[Continuous Integration/rspec  ]   🐳  docker pull image=mysql:8.4 platform=linux/amd64 username= forcePull=true
[Continuous Integration/rspec  ]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform=linux/amd64 username= forcePull=true
[Continuous Integration/rubocop]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Continuous Integration/eslint ]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Continuous Integration/eslint ]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Continuous Integration/rubocop]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Continuous Integration/eslint ]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
[Continuous Integration/rubocop]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
[Continuous Integration/eslint ]   ☁  git clone 'https://github.com/actions/cache' # ref=v3
[Continuous Integration/rubocop]   ☁  git clone 'https://github.com/actions/cache' # ref=v3
[Continuous Integration/eslint ] Non-terminating error while running 'git clone': some refs were not updated
[Continuous Integration/eslint ] ⭐ Run Main Checkout code
[Continuous Integration/eslint ]   🐳  docker cp src=/Users/itowokashigenari/git/tetsuya-shyline/. dst=/Users/itowokashigenari/git/tetsuya-shyline
[Continuous Integration/rspec  ] Cleaning up services for job rspec
[Continuous Integration/rspec  ] Cleaning up network for job rspec, and network name is: act-Continuous-Integration-rspec-0878032d17d0fdc48cf92440996482429ebd39d0576a4a1b50707216de896419-rspec-network
[Continuous Integration/rspec  ]   🐳  docker pull image=mysql:8.4 platform=linux/amd64 username= forcePull=false
[Continuous Integration/rspec  ]   🐳  docker create image=mysql:8.4 platform=linux/amd64 entrypoint=[] cmd=[] network="act-Continuous-Integration-rspec-0878032d17d0fdc48cf92440996482429ebd39d0576a4a1b50707216de896419-rspec-network"
[Continuous Integration/rspec  ]   🐳  docker run image=mysql:8.4 platform=linux/amd64 entrypoint=[] cmd=[] network="act-Continuous-Integration-rspec-0878032d17d0fdc48cf92440996482429ebd39d0576a4a1b50707216de896419-rspec-network"
[Continuous Integration/eslint ]   ✅  Success - Main Checkout code
[Continuous Integration/eslint ]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/workflow/hashfiles/index.js] user= workdir=
[Continuous Integration/rubocop] Non-terminating error while running 'git clone': some refs were not updated
[Continuous Integration/rubocop]   ☁  git clone 'https://github.com/ruby/setup-ruby' # ref=v1
[Continuous Integration/rspec  ]   🐳  docker create image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Continuous Integration/rspec  ]   🐳  docker run image=catthehacker/ubuntu:act-latest platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Continuous Integration/rspec  ] container health of 15ad50d3030865d6598cd35de0d6702d0c57493de0ca91efb9271d70fa4821ca (mysql:8.4) is starting
[Continuous Integration/eslint ] ⭐ Run Main Cache node modules
[Continuous Integration/eslint ]   🐳  docker cp src=/Users/itowokashigenari/.cache/act/actions-cache@v3/ dst=/var/run/act/actions/actions-cache@v3/
[Continuous Integration/rspec  ] container health of 15ad50d3030865d6598cd35de0d6702d0c57493de0ca91efb9271d70fa4821ca (mysql:8.4) is starting
[Continuous Integration/eslint ]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/actions/actions-cache@v3/dist/restore/index.js] user= workdir=
[Continuous Integration/rubocop] ⭐ Run Main Checkout code
[Continuous Integration/rubocop]   🐳  docker cp src=/Users/itowokashigenari/git/tetsuya-shyline/. dst=/Users/itowokashigenari/git/tetsuya-shyline
[Continuous Integration/rubocop]   ✅  Success - Main Checkout code
[Continuous Integration/rubocop]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/workflow/hashfiles/index.js] user= workdir=
[Continuous Integration/eslint ]   💬  ::debug::Resolved Keys:
[Continuous Integration/eslint ]   💬  ::debug::["Linux-node-45d992a3f41658109f5db0b0c345142347954ef95ff271c9f66df764a35c9064","Linux-node-"]
[Continuous Integration/eslint ]   💬  ::debug::Checking zstd --quiet --version
[Continuous Integration/eslint ]   💬  ::debug::1.4.8
[Continuous Integration/eslint ]   💬  ::debug::zstd version: 1.4.8
[Continuous Integration/eslint ]   💬  ::debug::Resource Url: http://192.168.3.40:53407/_apis/artifactcache/cache?keys=Linux-node-45d992a3f41658109f5db0b0c345142347954ef95ff271c9f66df764a35c9064%252CLinux-node-&version=9a59f2b653346f57dc5ebbb7d719860e2b175dc6b2cc180a0ad796bed5cf7092
[Continuous Integration/eslint ]   ⚙  ***
[Continuous Integration/eslint ]   💬  ::debug::Cache Result:
[Continuous Integration/eslint ]   💬  ::debug::{"archiveLocation":"***","cacheKey":"linux-node-45d992a3f41658109f5db0b0c345142347954ef95ff271c9f66df764a35c9064","result":"hit"}
[Continuous Integration/eslint ]   💬  ::debug::Archive Path: /tmp/bda42d93-9531-4dd3-bb8e-c2b10b26f089/cache.tzst
[Continuous Integration/eslint ]   💬  ::debug::Use Azure SDK: false
[Continuous Integration/eslint ]   💬  ::debug::Download concurrency: 8
[Continuous Integration/eslint ]   💬  ::debug::Request timeout (ms): 30000
[Continuous Integration/eslint ]   💬  ::debug::Cache segment download timeout mins env var: undefined
[Continuous Integration/eslint ]   💬  ::debug::Segment download timeout (ms): 600000
[Continuous Integration/eslint ]   💬  ::debug::Lookup only: false
| Cache Size: ~20 MB (20490388 B)
| [command]/usr/bin/tar -xf /tmp/bda42d93-9531-4dd3-bb8e-c2b10b26f089/cache.tzst -P -C /Users/itowokashigenari/git/tetsuya-shyline --use-compress-program unzstd
[Continuous Integration/rubocop] ⭐ Run Main Cache bundler dependencies
[Continuous Integration/rubocop]   🐳  docker cp src=/Users/itowokashigenari/.cache/act/actions-cache@v3/ dst=/var/run/act/actions/actions-cache@v3/
[Continuous Integration/rspec  ] container health of 15ad50d3030865d6598cd35de0d6702d0c57493de0ca91efb9271d70fa4821ca (mysql:8.4) is starting
| Cache restored successfully
| Cache restored from key: linux-node-45d992a3f41658109f5db0b0c345142347954ef95ff271c9f66df764a35c9064
[Continuous Integration/eslint ]   ✅  Success - Main Cache node modules
[Continuous Integration/eslint ]   ⚙  ::set-output:: cache-hit=true
[Continuous Integration/eslint ] ⭐ Run Main Install packages
[Continuous Integration/rubocop]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/actions/actions-cache@v3/dist/restore/index.js] user= workdir=
[Continuous Integration/eslint ]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/2] user= workdir=frontend/app
[Continuous Integration/rubocop]   💬  ::debug::Resolved Keys:
[Continuous Integration/rubocop]   💬  ::debug::["Linux-bundler-ad1382541ded0bb1ee3effc6ed2872797f7bd73e523c55be38cc3fd681572df7","Linux-bundler-"]
[Continuous Integration/rubocop]   💬  ::debug::Checking zstd --quiet --version
[Continuous Integration/rubocop]   💬  ::debug::1.4.8
[Continuous Integration/rubocop]   💬  ::debug::zstd version: 1.4.8
[Continuous Integration/rubocop]   💬  ::debug::Resource Url: http://192.168.3.40:53407/_apis/artifactcache/cache?keys=Linux-bundler-ad1382541ded0bb1ee3effc6ed2872797f7bd73e523c55be38cc3fd681572df7%252CLinux-bundler-&version=f3a190c975da8339aef2d723682c8fb06999ced0c1e8592447dabecbf40062e3
[Continuous Integration/rubocop]   💬  ::debug::Failed to delete archive: Error: ENOENT: no such file or directory, unlink ''
| Cache not found for input keys: Linux-bundler-ad1382541ded0bb1ee3effc6ed2872797f7bd73e523c55be38cc3fd681572df7, Linux-bundler-
[Continuous Integration/rubocop]   ✅  Success - Main Cache bundler dependencies
[Continuous Integration/rubocop] ⭐ Run Main Set up Ruby
[Continuous Integration/rubocop]   🐳  docker cp src=/Users/itowokashigenari/.cache/act/ruby-setup-ruby@v1/ dst=/var/run/act/actions/ruby-setup-ruby@v1/
[Continuous Integration/rubocop]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/actions/ruby-setup-ruby@v1/dist/index.js] user= workdir=
[Continuous Integration/rubocop]   💬  ::debug::isExplicit: 3.4.1
[Continuous Integration/rubocop]   💬  ::debug::explicit? true
[Continuous Integration/rubocop]   💬  ::debug::checking cache: /opt/hostedtoolcache/Ruby/3.4.1/x64
[Continuous Integration/rubocop]   💬  ::debug::Found tool in cache Ruby 3.4.1 x64
[Continuous Integration/rubocop]   ❓  ::group::Modifying PATH
| Entries added to PATH to use selected Ruby:
|   /opt/hostedtoolcache/Ruby/3.4.1/x64/bin
[Continuous Integration/rubocop]   ❓  ::endgroup::
[Continuous Integration/rubocop]   ❓  ::group::Print Ruby version
| [command]/opt/hostedtoolcache/Ruby/3.4.1/x64/bin/ruby --version
| ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
| Took   0.14 seconds
[Continuous Integration/rubocop]   ❓  ::endgroup::
[Continuous Integration/rubocop]   ❓  ::group::Installing Bundler
| Using Bundler 2 shipped with ruby-3.4.1
| Took   0.00 seconds
[Continuous Integration/rubocop]   ❓  ::endgroup::
| > bundle install
| Could not determine gemfile path, skipping "bundle install" and caching
| Took   0.00 seconds
[Continuous Integration/rubocop]   ✅  Success - Main Set up Ruby
[Continuous Integration/rubocop]   ⚙  ::set-output:: ruby-prefix=/opt/hostedtoolcache/Ruby/3.4.1/x64
[Continuous Integration/rubocop]   ⚙  ::add-path:: /opt/hostedtoolcache/Ruby/3.4.1/x64/bin
[Continuous Integration/rubocop] ⭐ Run Main Bundler and gem install
[Continuous Integration/rubocop]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/3] user= workdir=backend
| npm warn EBADENGINE Unsupported engine {
| npm warn EBADENGINE   package: 'react-router@7.1.3',
| npm warn EBADENGINE   required: { node: '>=20.0.0' },
| npm warn EBADENGINE   current: { node: 'v18.20.5', npm: '10.8.2' }
| npm warn EBADENGINE }
| npm warn EBADENGINE Unsupported engine {
| npm warn EBADENGINE   package: 'react-router-dom@7.1.3',
| npm warn EBADENGINE   required: { node: '>=20.0.0' },
| npm warn EBADENGINE   current: { node: 'v18.20.5', npm: '10.8.2' }
| npm warn EBADENGINE }
[Continuous Integration/rspec  ] container health of 15ad50d3030865d6598cd35de0d6702d0c57493de0ca91efb9271d70fa4821ca (mysql:8.4) is starting
| 
| up to date, audited 203 packages in 3s
| 
| 45 packages are looking for funding
|   run `npm fund` for details
| 
| found 0 vulnerabilities
[Continuous Integration/eslint ]   ✅  Success - Main Install packages
[Continuous Integration/eslint ] ⭐ Run Main Run lint
[Continuous Integration/eslint ]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/3] user= workdir=frontend/app
| Successfully installed bundler-2.6.3
| 1 gem installed
| 
| > app@0.0.0 lint
| > eslint src
| 
| Don't run Bundler as root. Installing your bundle as root will break this
| application for all non-root users on this machine.
[Continuous Integration/eslint ]   ✅  Success - Main Run lint
[Continuous Integration/eslint ]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/workflow/hashfiles/index.js] user= workdir=
[Continuous Integration/eslint ] ⭐ Run Post Cache node modules
[Continuous Integration/eslint ]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/actions/actions-cache@v3/dist/save/index.js] user= workdir=
[Continuous Integration/eslint ]   💬  ::debug::Cache state/key: linux-node-45d992a3f41658109f5db0b0c345142347954ef95ff271c9f66df764a35c9064
| Cache hit occurred on the primary key Linux-node-45d992a3f41658109f5db0b0c345142347954ef95ff271c9f66df764a35c9064, not saving cache.
[Continuous Integration/eslint ]   ✅  Success - Post Cache node modules
[Continuous Integration/eslint ] Cleaning up container for job eslint
[Continuous Integration/eslint ] 🏁  Job succeeded
[Continuous Integration/rspec  ] container health of 15ad50d3030865d6598cd35de0d6702d0c57493de0ca91efb9271d70fa4821ca (mysql:8.4) is starting
| Fetching gem metadata from https://rubygems.org/.........
| Resolving dependencies...
| Resolving dependencies...
| Fetching rake 13.2.1
| Installing rake 13.2.1
| Fetching base64 0.2.0
| Fetching benchmark 0.4.0
| Fetching bigdecimal 3.1.9
| Fetching concurrent-ruby 1.3.5
| Installing base64 0.2.0
| Fetching connection_pool 2.5.0
| Installing benchmark 0.4.0
| Fetching drb 2.2.1
| Installing bigdecimal 3.1.9 with native extensions
| Installing concurrent-ruby 1.3.5
| Installing connection_pool 2.5.0
| Fetching logger 1.6.5
| Installing drb 2.2.1
| Installing logger 1.6.5
| Fetching minitest 5.25.4
| Fetching securerandom 0.4.1
| Installing minitest 5.25.4
| Installing securerandom 0.4.1
| Fetching uri 1.0.2
| Fetching builder 3.3.0
| Fetching erubi 1.13.1
| Installing uri 1.0.2
| Fetching racc 1.8.1
| Installing builder 3.3.0
| Fetching crass 1.0.6
| Installing erubi 1.13.1
| Fetching rack 3.1.8
| Installing racc 1.8.1 with native extensions
| Installing crass 1.0.6
| Fetching useragent 0.16.11
| Installing rack 3.1.8
| Installing useragent 0.16.11
| Fetching nio4r 2.7.4
| Fetching websocket-extensions 0.1.5
| Installing nio4r 2.7.4 with native extensions
| Installing websocket-extensions 0.1.5
| Fetching zeitwerk 2.7.1
| Installing zeitwerk 2.7.1
| Fetching timeout 0.4.3
| Installing timeout 0.4.3
| Fetching marcel 1.0.4
| Installing marcel 1.0.4
| Fetching mini_mime 1.1.5
| Installing mini_mime 1.1.5
| Fetching date 3.4.1
| Installing date 3.4.1 with native extensions
| Fetching ast 2.4.2
| Installing ast 2.4.2
| Fetching bcrypt_pbkdf 1.1.1
| Installing bcrypt_pbkdf 1.1.1 with native extensions
| Fetching msgpack 1.7.5
| Installing msgpack 1.7.5 with native extensions
[Continuous Integration/rspec  ] container health of 15ad50d3030865d6598cd35de0d6702d0c57493de0ca91efb9271d70fa4821ca (mysql:8.4) is healthy
[Continuous Integration/rspec  ]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
[Continuous Integration/rspec  ]   ☁  git clone 'https://github.com/actions/cache' # ref=v3
[Continuous Integration/rspec  ] Non-terminating error while running 'git clone': some refs were not updated
[Continuous Integration/rspec  ]   ☁  git clone 'https://github.com/ruby/setup-ruby' # ref=v1
[Continuous Integration/rspec  ] ⭐ Run Main Checkout code
[Continuous Integration/rspec  ]   🐳  docker cp src=/Users/itowokashigenari/git/tetsuya-shyline/. dst=/Users/itowokashigenari/git/tetsuya-shyline
[Continuous Integration/rspec  ]   ✅  Success - Main Checkout code
[Continuous Integration/rspec  ]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/workflow/hashfiles/index.js] user= workdir=
[Continuous Integration/rspec  ] ⭐ Run Main Cache bundler dependencies
[Continuous Integration/rspec  ]   🐳  docker cp src=/Users/itowokashigenari/.cache/act/actions-cache@v3/ dst=/var/run/act/actions/actions-cache@v3/
[Continuous Integration/rspec  ]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/actions/actions-cache@v3/dist/restore/index.js] user= workdir=
| Fetching byebug 11.1.3
[Continuous Integration/rspec  ]   💬  ::debug::Resolved Keys:
[Continuous Integration/rspec  ]   💬  ::debug::["Linux-bundler-ad1382541ded0bb1ee3effc6ed2872797f7bd73e523c55be38cc3fd681572df7","Linux-bundler-"]
[Continuous Integration/rspec  ]   💬  ::debug::Checking zstd --quiet --version
[Continuous Integration/rspec  ]   💬  ::debug::1.4.8
[Continuous Integration/rspec  ]   💬  ::debug::zstd version: 1.4.8
[Continuous Integration/rspec  ]   💬  ::debug::Resource Url: http://192.168.3.40:53407/_apis/artifactcache/cache?keys=Linux-bundler-ad1382541ded0bb1ee3effc6ed2872797f7bd73e523c55be38cc3fd681572df7%252CLinux-bundler-&version=f3a190c975da8339aef2d723682c8fb06999ced0c1e8592447dabecbf40062e3
[Continuous Integration/rspec  ]   💬  ::debug::Failed to delete archive: Error: ENOENT: no such file or directory, unlink ''
| Cache not found for input keys: Linux-bundler-ad1382541ded0bb1ee3effc6ed2872797f7bd73e523c55be38cc3fd681572df7, Linux-bundler-
[Continuous Integration/rspec  ]   ✅  Success - Main Cache bundler dependencies
| Installing byebug 11.1.3 with native extensions
[Continuous Integration/rspec  ] ⭐ Run Main Set up Ruby
[Continuous Integration/rspec  ]   🐳  docker cp src=/Users/itowokashigenari/.cache/act/ruby-setup-ruby@v1/ dst=/var/run/act/actions/ruby-setup-ruby@v1/
[Continuous Integration/rspec  ]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/actions/ruby-setup-ruby@v1/dist/index.js] user= workdir=
[Continuous Integration/rspec  ]   💬  ::debug::isExplicit: 3.4.1
[Continuous Integration/rspec  ]   💬  ::debug::explicit? true
[Continuous Integration/rspec  ]   💬  ::debug::checking cache: /opt/hostedtoolcache/Ruby/3.4.1/x64
[Continuous Integration/rspec  ]   💬  ::debug::Found tool in cache Ruby 3.4.1 x64
[Continuous Integration/rspec  ]   ❓  ::group::Modifying PATH
| Entries added to PATH to use selected Ruby:
|   /opt/hostedtoolcache/Ruby/3.4.1/x64/bin
[Continuous Integration/rspec  ]   ❓  ::endgroup::
[Continuous Integration/rspec  ]   ❓  ::group::Print Ruby version
| [command]/opt/hostedtoolcache/Ruby/3.4.1/x64/bin/ruby --version
| ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
| Took   0.15 seconds
[Continuous Integration/rspec  ]   ❓  ::endgroup::
[Continuous Integration/rspec  ]   ❓  ::group::Installing Bundler
| Using Bundler 2 shipped with ruby-3.4.1
| Took   0.00 seconds
[Continuous Integration/rspec  ]   ❓  ::endgroup::
| > bundle install
| Could not determine gemfile path, skipping "bundle install" and caching
| Took   0.00 seconds
[Continuous Integration/rspec  ]   ✅  Success - Main Set up Ruby
[Continuous Integration/rspec  ]   ⚙  ::set-output:: ruby-prefix=/opt/hostedtoolcache/Ruby/3.4.1/x64
[Continuous Integration/rspec  ]   ⚙  ::add-path:: /opt/hostedtoolcache/Ruby/3.4.1/x64/bin
[Continuous Integration/rspec  ] ⭐ Run Main Bundler and gem install
[Continuous Integration/rspec  ]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/3] user= workdir=backend
| Successfully installed bundler-2.6.3
| 1 gem installed
| Fetching coderay 1.1.3
| Installing coderay 1.1.3
| Fetching stringio 3.1.2
| Installing stringio 3.1.2 with native extensions
| Don't run Bundler as root. Installing your bundle as root will break this
| application for all non-root users on this machine.
| Fetching io-console 0.8.0
| Installing io-console 0.8.0 with native extensions
| Fetching diff-lcs 1.5.1
| Installing diff-lcs 1.5.1
| Fetching diffy 3.4.3
| Installing diffy 3.4.3
| Fetching dotenv 3.1.7
| Installing dotenv 3.1.7
| Fetching ed25519 1.3.0
| Installing ed25519 1.3.0 with native extensions
| Fetching gem metadata from https://rubygems.org/.........
| Resolving dependencies...
| Resolving dependencies...
| Fetching rake 13.2.1
| Installing rake 13.2.1
| Fetching base64 0.2.0
| Fetching benchmark 0.4.0
| Fetching bigdecimal 3.1.9
| Fetching concurrent-ruby 1.3.5
| Installing base64 0.2.0
| Fetching connection_pool 2.5.0
| Installing benchmark 0.4.0
| Fetching drb 2.2.1
| Installing bigdecimal 3.1.9 with native extensions
| Installing connection_pool 2.5.0
| Installing drb 2.2.1
| Fetching logger 1.6.5
| Fetching minitest 5.25.4
| Installing logger 1.6.5
| Installing concurrent-ruby 1.3.5
| Installing minitest 5.25.4
| Fetching securerandom 0.4.1
| Installing securerandom 0.4.1
| Fetching uri 1.0.2
| Fetching builder 3.3.0
| Installing uri 1.0.2
| Installing builder 3.3.0
| Fetching erubi 1.13.1
| Installing erubi 1.13.1
| Fetching racc 1.8.1
| Fetching crass 1.0.6
| Fetching rack 3.1.8
| Installing racc 1.8.1 with native extensions
| Installing crass 1.0.6
| Installing rack 3.1.8
| Fetching useragent 0.16.11
| Fetching nio4r 2.7.4
| Installing useragent 0.16.11
| Fetching websocket-extensions 0.1.5
| Installing websocket-extensions 0.1.5
| Installing nio4r 2.7.4 with native extensions
| Fetching zeitwerk 2.7.1
| Installing zeitwerk 2.7.1
| Fetching timeout 0.4.3
| Installing timeout 0.4.3
| Fetching marcel 1.0.4
| Installing marcel 1.0.4
| Fetching mini_mime 1.1.5
| Installing mini_mime 1.1.5
| Fetching date 3.4.1
| Installing date 3.4.1 with native extensions
| Fetching ast 2.4.2
| Installing ast 2.4.2
| Fetching bcrypt_pbkdf 1.1.1
| Installing bcrypt_pbkdf 1.1.1 with native extensions
| Fetching thor 1.3.2
| Installing thor 1.3.2
| Fetching raabro 1.4.0
| Fetching json 2.9.1
| Installing raabro 1.4.0
| Fetching net-ssh 7.3.0
| Installing json 2.9.1 with native extensions
| Installing net-ssh 7.3.0
| Fetching ostruct 0.6.1
| Installing ostruct 0.6.1
| Fetching language_server-protocol 3.17.0.3
| Installing language_server-protocol 3.17.0.3
| Fetching method_source 1.1.0
| Installing method_source 1.1.0
| Fetching mysql2 0.5.6
| Installing mysql2 0.5.6 with native extensions
| Fetching parallel 1.26.3
| Installing parallel 1.26.3
| Fetching yard 0.9.37
| Installing yard 0.9.37
| Fetching rainbow 3.1.1
| Installing rainbow 3.1.1
| Fetching regexp_parser 2.10.0
| Installing regexp_parser 2.10.0
| Fetching rspec-support 3.13.2
| Installing rspec-support 3.13.2
| Fetching ruby-progressbar 1.13.0
| Installing ruby-progressbar 1.13.0
| Fetching unicode-emoji 4.0.4
| Installing unicode-emoji 4.0.4
| Fetching spring 4.2.1
| Installing spring 4.2.1
| Fetching thruster 0.1.10 (x86_64-linux)
| Installing thruster 0.1.10 (x86_64-linux)
| Fetching i18n 1.14.7
| Installing i18n 1.14.7
| Fetching tzinfo 2.0.6
| Installing tzinfo 2.0.6
| Fetching rack-session 2.1.0
| Installing rack-session 2.1.0
| Fetching rack-test 2.2.0
| Installing rack-test 2.2.0
| Fetching rackup 2.2.1
| Installing rackup 2.2.1
| Fetching rack-cors 2.0.2
| Installing rack-cors 2.0.2
| Fetching websocket-driver 0.7.7
| Installing websocket-driver 0.7.7 with native extensions
| Fetching msgpack 1.7.5
| Installing msgpack 1.7.5 with native extensions
| Fetching net-protocol 0.2.2
| Installing net-protocol 0.2.2
| Fetching nokogiri 1.18.2 (x86_64-linux-gnu)
| Installing nokogiri 1.18.2 (x86_64-linux-gnu)
| Fetching brakeman 7.0.0
| Installing brakeman 7.0.0
| Fetching parser 3.3.7.0
| Installing parser 3.3.7.0
| Fetching puma 6.5.0
| Installing puma 6.5.0 with native extensions
| Fetching psych 5.2.3
| Installing psych 5.2.3 with native extensions
| Fetching byebug 11.1.3
| Installing byebug 11.1.3 with native extensions
| Fetching coderay 1.1.3
| Fetching net-scp 4.0.0
| Installing net-scp 4.0.0
| Fetching net-sftp 4.0.0
| Installing coderay 1.1.3
| Installing net-sftp 4.0.0
| Fetching pry 0.14.2
| Installing pry 0.14.2
| Fetching stringio 3.1.2
| Installing stringio 3.1.2 with native extensions
| Fetching bootsnap 1.18.4
| Installing bootsnap 1.18.4 with native extensions
| Fetching rspec-core 3.13.2
| Installing rspec-core 3.13.2
| Fetching rspec-expectations 3.13.3
| Installing rspec-expectations 3.13.3
| Fetching rspec-mocks 3.13.2
| Installing rspec-mocks 3.13.2
| Fetching unicode-display_width 3.1.4
| Installing unicode-display_width 3.1.4
| Fetching spring-commands-rspec 1.0.4
| Installing spring-commands-rspec 1.0.4
| Fetching activesupport 8.0.1
| Installing activesupport 8.0.1
| Fetching et-orbi 1.2.11
| Installing et-orbi 1.2.11
| Fetching net-imap 0.5.5
| Installing net-imap 0.5.5
| Fetching net-pop 0.1.2
| Installing net-pop 0.1.2
| Fetching net-smtp 0.5.0
| Installing net-smtp 0.5.0
| Fetching loofah 2.24.0
| Installing loofah 2.24.0
| Fetching rubocop-ast 1.37.0
| Installing rubocop-ast 1.37.0
| Fetching reline 0.6.0
| Installing reline 0.6.0
| Fetching sshkit 1.23.2
| Installing sshkit 1.23.2
| Fetching pry-byebug 3.10.1
| Installing pry-byebug 3.10.1
| Fetching pry-doc 1.5.0
| Fetching io-console 0.8.0
| Fetching diff-lcs 1.5.1
| Installing io-console 0.8.0 with native extensions
| Installing diff-lcs 1.5.1
| Fetching diffy 3.4.3
| Installing diffy 3.4.3
| Fetching dotenv 3.1.7
| Installing dotenv 3.1.7
| Fetching ed25519 1.3.0
| Installing ed25519 1.3.0 with native extensions
| Installing pry-doc 1.5.0
| Fetching pry-rails 0.3.11
| Installing pry-rails 0.3.11
| Fetching rdoc 6.11.0
| Installing rdoc 6.11.0
| Fetching rails-dom-testing 2.2.0
| Installing rails-dom-testing 2.2.0
| Fetching globalid 1.2.1
| Installing globalid 1.2.1
| Fetching activemodel 8.0.1
| Installing activemodel 8.0.1
| Fetching factory_bot 6.5.0
| Installing factory_bot 6.5.0
| Fetching fugit 1.11.1
| Installing fugit 1.11.1
| Fetching mail 2.8.1
| Installing mail 2.8.1
| Fetching rails-html-sanitizer 1.6.2
| Installing rails-html-sanitizer 1.6.2
| Fetching rubocop 1.70.0
| Installing rubocop 1.70.0
| Fetching kamal 2.4.0
| Installing kamal 2.4.0
| Fetching irb 1.14.3
| Installing irb 1.14.3
| Fetching activejob 8.0.1
| Fetching activerecord 8.0.1
| Installing activejob 8.0.1
| Fetching actionview 8.0.1
| Installing activerecord 8.0.1
| Installing actionview 8.0.1
| Fetching rubocop-minitest 0.36.0
| Installing rubocop-minitest 0.36.0
| Fetching rubocop-performance 1.23.1
| Installing rubocop-performance 1.23.1
| Fetching rubocop-rails 2.29.0
| Fetching rubocop-rspec 3.4.0
| Installing rubocop-rails 2.29.0
| Installing rubocop-rspec 3.4.0
| Fetching debug 1.10.0
| Fetching actionpack 8.0.1
| Installing debug 1.10.0 with native extensions
| Installing actionpack 8.0.1
| Fetching ridgepole 3.0.1
| Installing ridgepole 3.0.1
| Fetching rubocop-rails-omakase 1.0.0
| Installing rubocop-rails-omakase 1.0.0
| Fetching actioncable 8.0.1
| Installing actioncable 8.0.1
| Fetching activestorage 8.0.1
| Installing activestorage 8.0.1
| Fetching actionmailer 8.0.1
| Installing actionmailer 8.0.1
| Fetching railties 8.0.1
| Installing railties 8.0.1
| Fetching actionmailbox 8.0.1
| Installing actionmailbox 8.0.1
| Fetching actiontext 8.0.1
| Installing actiontext 8.0.1
| Fetching factory_bot_rails 6.4.4
| Installing factory_bot_rails 6.4.4
| Fetching rspec-rails 7.1.0
| Installing rspec-rails 7.1.0
| Fetching solid_cable 3.0.5
| Installing solid_cable 3.0.5
| Fetching solid_cache 1.0.6
| Installing solid_cache 1.0.6
| Fetching solid_queue 1.1.2
| Installing solid_queue 1.1.2
| Fetching rails 8.0.1
| Installing rails 8.0.1
| Fetching thor 1.3.2
| Installing thor 1.3.2
| Fetching raabro 1.4.0
| Installing raabro 1.4.0
| Fetching json 2.9.1
| Installing json 2.9.1 with native extensions
| Fetching net-ssh 7.3.0
| Installing net-ssh 7.3.0
| Fetching ostruct 0.6.1
| Installing ostruct 0.6.1
| Fetching language_server-protocol 3.17.0.3
| Installing language_server-protocol 3.17.0.3
| Fetching method_source 1.1.0
| Installing method_source 1.1.0
| Fetching mysql2 0.5.6
| Installing mysql2 0.5.6 with native extensions
| Fetching parallel 1.26.3
| Installing parallel 1.26.3
| Fetching yard 0.9.37
| Installing yard 0.9.37
| Fetching rainbow 3.1.1
| Installing rainbow 3.1.1
| Fetching regexp_parser 2.10.0
| Installing regexp_parser 2.10.0
| Fetching rspec-support 3.13.2
| Installing rspec-support 3.13.2
| Fetching ruby-progressbar 1.13.0
| Installing ruby-progressbar 1.13.0
| Fetching unicode-emoji 4.0.4
| Installing unicode-emoji 4.0.4
| Fetching spring 4.2.1
| Installing spring 4.2.1
| Fetching thruster 0.1.10 (x86_64-linux)
| Installing thruster 0.1.10 (x86_64-linux)
| Fetching i18n 1.14.7
| Installing i18n 1.14.7
| Fetching tzinfo 2.0.6
| Installing tzinfo 2.0.6
| Fetching rack-session 2.1.0
| Installing rack-session 2.1.0
| Fetching rack-test 2.2.0
| Installing rack-test 2.2.0
| Fetching rackup 2.2.1
| Installing rackup 2.2.1
| Fetching rack-cors 2.0.2
| Installing rack-cors 2.0.2
| Fetching websocket-driver 0.7.7
| Installing websocket-driver 0.7.7 with native extensions
| Fetching net-protocol 0.2.2
| Installing net-protocol 0.2.2
| Fetching nokogiri 1.18.2 (x86_64-linux-gnu)
| Installing nokogiri 1.18.2 (x86_64-linux-gnu)
| Bundle complete! 25 Gemfile dependencies, 121 gems now installed.
| Bundled gems are installed into `./vendor/bundle`
| Post-install message from solid_cache:
| Upgrading from Solid Cache v0.3 or earlier? There are new database migrations in v0.4.
| See https://github.com/rails/solid_cache/blob/main/upgrading_to_version_0.4.x.md for upgrade instructions.
| Post-install message from solid_queue:
| Upgrading to Solid Queue 0.9.0? There are some breaking changes about how recurring tasks are configured.
| 
| Upgrading to Solid Queue 0.8.0 from < 0.6.0? You need to upgrade to 0.6.0 first.
| 
| Upgrading to Solid Queue 0.4.x, 0.5.x, 0.6.x or 0.7.x? There are some breaking changes about how Solid Queue is started,
| configuration and new migrations.
| 
| --> Check https://github.com/rails/solid_queue/blob/main/UPGRADING.md
| for upgrade instructions.
| Fetching brakeman 7.0.0
[Continuous Integration/rubocop]   ✅  Success - Main Bundler and gem install
[Continuous Integration/rubocop] ⭐ Run Main Run rubocop
[Continuous Integration/rubocop]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/4] user= workdir=backend
| Installing brakeman 7.0.0
| Fetching parser 3.3.7.0
| Installing parser 3.3.7.0
| Fetching puma 6.5.0
| Installing puma 6.5.0 with native extensions
| Fetching psych 5.2.3
| Installing psych 5.2.3 with native extensions
| RuboCop server starting on 127.0.0.1:56977.
| Inspecting 24 files
| ........................
| 
| 24 files inspected, no offenses detected
[Continuous Integration/rubocop]   ✅  Success - Main Run rubocop
[Continuous Integration/rubocop]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/workflow/hashfiles/index.js] user= workdir=
| Fetching net-scp 4.0.0
| Installing net-scp 4.0.0
| Fetching net-sftp 4.0.0
| Installing net-sftp 4.0.0
| Fetching pry 0.14.2
| Installing pry 0.14.2
| Fetching bootsnap 1.18.4
| Installing bootsnap 1.18.4 with native extensions
| Fetching rspec-core 3.13.2
| Installing rspec-core 3.13.2
| Fetching rspec-expectations 3.13.3
| Installing rspec-expectations 3.13.3
| Fetching rspec-mocks 3.13.2
| Installing rspec-mocks 3.13.2
| Fetching unicode-display_width 3.1.4
| Installing unicode-display_width 3.1.4
| Fetching spring-commands-rspec 1.0.4
| Installing spring-commands-rspec 1.0.4
| Fetching activesupport 8.0.1
| Installing activesupport 8.0.1
| Fetching et-orbi 1.2.11
| Installing et-orbi 1.2.11
| Fetching net-imap 0.5.5
| Installing net-imap 0.5.5
| Fetching net-pop 0.1.2
| Installing net-pop 0.1.2
| Fetching net-smtp 0.5.0
| Installing net-smtp 0.5.0
| Fetching loofah 2.24.0
| Installing loofah 2.24.0
| Fetching rubocop-ast 1.37.0
| Installing rubocop-ast 1.37.0
| Fetching reline 0.6.0
| Installing reline 0.6.0
| Fetching sshkit 1.23.2
| Installing sshkit 1.23.2
| Fetching pry-byebug 3.10.1
| Installing pry-byebug 3.10.1
| Fetching pry-doc 1.5.0
[Continuous Integration/rubocop] ⭐ Run Post Cache bundler dependencies
[Continuous Integration/rubocop]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/actions/actions-cache@v3/dist/save/index.js] user= workdir=
[Continuous Integration/rubocop]   💬  ::debug::Checking zstd --quiet --version
[Continuous Integration/rubocop]   💬  ::debug::1.4.8
[Continuous Integration/rubocop]   💬  ::debug::zstd version: 1.4.8
[Continuous Integration/rubocop]   💬  ::debug::implicitDescendants 'false'
[Continuous Integration/rubocop]   💬  ::debug::followSymbolicLinks 'true'
[Continuous Integration/rubocop]   💬  ::debug::implicitDescendants 'false'
[Continuous Integration/rubocop]   💬  ::debug::omitBrokenSymbolicLinks 'true'
[Continuous Integration/rubocop]   💬  ::debug::Search path '/Users/itowokashigenari/git/tetsuya-shyline/vendor/bundle'
[Continuous Integration/rubocop]   💬  ::debug::Cache Paths:
[Continuous Integration/rubocop]   💬  ::debug::[]
| [warning]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
| Installing pry-doc 1.5.0
[Continuous Integration/rubocop]   ✅  Success - Post Cache bundler dependencies
[Continuous Integration/rubocop] Cleaning up container for job rubocop
| Fetching pry-rails 0.3.11
[Continuous Integration/rubocop] 🏁  Job succeeded
| Installing pry-rails 0.3.11
| Fetching rdoc 6.11.0
| Fetching rails-dom-testing 2.2.0
| Installing rails-dom-testing 2.2.0
| Fetching globalid 1.2.1
| Installing rdoc 6.11.0
| Installing globalid 1.2.1
| Fetching activemodel 8.0.1
| Installing activemodel 8.0.1
| Fetching factory_bot 6.5.0
| Fetching fugit 1.11.1
| Installing factory_bot 6.5.0
| Fetching mail 2.8.1
| Installing fugit 1.11.1
| Fetching rails-html-sanitizer 1.6.2
| Installing mail 2.8.1
| Installing rails-html-sanitizer 1.6.2
| Fetching rubocop 1.70.0
| Fetching kamal 2.4.0
| Installing rubocop 1.70.0
| Installing kamal 2.4.0
| Fetching activejob 8.0.1
| Installing activejob 8.0.1
| Fetching activerecord 8.0.1
| Installing activerecord 8.0.1
| Fetching irb 1.14.3
| Fetching actionview 8.0.1
| Installing irb 1.14.3
| Installing actionview 8.0.1
| Fetching ridgepole 3.0.1
| Installing ridgepole 3.0.1
| Fetching rubocop-minitest 0.36.0
| Fetching rubocop-performance 1.23.1
| Installing rubocop-minitest 0.36.0
| Installing rubocop-performance 1.23.1
| Fetching rubocop-rails 2.29.0
| Fetching rubocop-rspec 3.4.0
| Installing rubocop-rails 2.29.0
| Installing rubocop-rspec 3.4.0
| Fetching debug 1.10.0
| Fetching actionpack 8.0.1
| Installing debug 1.10.0 with native extensions
| Installing actionpack 8.0.1
| Fetching rubocop-rails-omakase 1.0.0
| Installing rubocop-rails-omakase 1.0.0
| Fetching actioncable 8.0.1
| Installing actioncable 8.0.1
| Fetching activestorage 8.0.1
| Installing activestorage 8.0.1
| Fetching actionmailer 8.0.1
| Installing actionmailer 8.0.1
| Fetching railties 8.0.1
| Installing railties 8.0.1
| Fetching actionmailbox 8.0.1
| Installing actionmailbox 8.0.1
| Fetching actiontext 8.0.1
| Installing actiontext 8.0.1
| Fetching factory_bot_rails 6.4.4
| Installing factory_bot_rails 6.4.4
| Fetching rspec-rails 7.1.0
| Installing rspec-rails 7.1.0
| Fetching solid_cable 3.0.5
| Installing solid_cable 3.0.5
| Fetching solid_cache 1.0.6
| Installing solid_cache 1.0.6
| Fetching solid_queue 1.1.2
| Installing solid_queue 1.1.2
| Fetching rails 8.0.1
| Installing rails 8.0.1
| Bundle complete! 25 Gemfile dependencies, 121 gems now installed.
| Bundled gems are installed into `./vendor/bundle`
| Post-install message from solid_cache:
| Upgrading from Solid Cache v0.3 or earlier? There are new database migrations in v0.4.
| See https://github.com/rails/solid_cache/blob/main/upgrading_to_version_0.4.x.md for upgrade instructions.
| Post-install message from solid_queue:
| Upgrading to Solid Queue 0.9.0? There are some breaking changes about how recurring tasks are configured.
| 
| Upgrading to Solid Queue 0.8.0 from < 0.6.0? You need to upgrade to 0.6.0 first.
| 
| Upgrading to Solid Queue 0.4.x, 0.5.x, 0.6.x or 0.7.x? There are some breaking changes about how Solid Queue is started,
| configuration and new migrations.
| 
| --> Check https://github.com/rails/solid_queue/blob/main/UPGRADING.md
| for upgrade instructions.
[Continuous Integration/rspec  ]   ✅  Success - Main Bundler and gem install
[Continuous Integration/rspec  ] ⭐ Run Main Database create and migrate
[Continuous Integration/rspec  ]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/4] user= workdir=backend
| ruby/3.4.1 isn't supported by this pry-doc version
| Created database 'api_test'
| Apply `db/schemas/Schemafile`
| -- create_table("test_examples", {charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC"})
|    -> 0.0417s
[Continuous Integration/rspec  ]   ✅  Success - Main Database create and migrate
[Continuous Integration/rspec  ] ⭐ Run Main Run rspec
[Continuous Integration/rspec  ]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/5] user= workdir=backend
| ruby/3.4.1 isn't supported by this pry-doc version
| Running via Spring preloader in process 1516
| ruby/3.4.1 isn't supported by this pry-doc version
| -- create_table("test_examples", {charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade})
|    -> 0.0537s
| .
| 
| Finished in 0.08775 seconds (files took 2.81 seconds to load)
| 1 example, 0 failures
| 
[Continuous Integration/rspec  ]   ✅  Success - Main Run rspec
[Continuous Integration/rspec  ]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/workflow/hashfiles/index.js] user= workdir=
[Continuous Integration/rspec  ] ⭐ Run Post Cache bundler dependencies
[Continuous Integration/rspec  ]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.5/x64/bin/node /var/run/act/actions/actions-cache@v3/dist/save/index.js] user= workdir=
[Continuous Integration/rspec  ]   💬  ::debug::Checking zstd --quiet --version
[Continuous Integration/rspec  ]   💬  ::debug::1.4.8
[Continuous Integration/rspec  ]   💬  ::debug::zstd version: 1.4.8
[Continuous Integration/rspec  ]   💬  ::debug::implicitDescendants 'false'
[Continuous Integration/rspec  ]   💬  ::debug::followSymbolicLinks 'true'
[Continuous Integration/rspec  ]   💬  ::debug::implicitDescendants 'false'
[Continuous Integration/rspec  ]   💬  ::debug::omitBrokenSymbolicLinks 'true'
[Continuous Integration/rspec  ]   💬  ::debug::Search path '/Users/itowokashigenari/git/tetsuya-shyline/vendor/bundle'
[Continuous Integration/rspec  ]   💬  ::debug::Cache Paths:
[Continuous Integration/rspec  ]   💬  ::debug::[]
| [warning]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
[Continuous Integration/rspec  ]   ✅  Success - Post Cache bundler dependencies
[Continuous Integration/rspec  ] Cleaning up container for job rspec
[Continuous Integration/rspec  ] Cleaning up services for job rspec
[Continuous Integration/rspec  ] Cleaning up network for job rspec, and network name is: act-Continuous-Integration-rspec-0878032d17d0fdc48cf92440996482429ebd39d0576a4a1b50707216de896419-rspec-network
[Continuous Integration/rspec  ] 🏁  Job succeeded
```