### PR TITLE
feat: deviseによる認証付きUserモデルを実装した

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -37,6 +37,15 @@ gem 'thruster', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 gem 'rack-cors'
 
+# ユーザー認証を提供[https://github.com/heartcombo/devise]
+gem 'devise'
+
+# deviseを日本語化する[https://github.com/tigrish/devise-i18n]
+gem 'devise-i18n'
+
+# ユーザーのトークン認証を提供する[https://github.com/lynndylanhurley/devise_token_auth]
+gem 'devise_token_auth'
+
 group :development, :test do
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem 'brakeman', require: false
@@ -46,6 +55,12 @@ group :development, :test do
 
   # https://github.com/thoughtbot/factory_bot
   gem 'factory_bot_rails'
+
+  # ダミーデータ生成[https://github.com/faker-ruby/faker]
+  gem 'faker'
+
+  # メール送信をテストする[https://github.com/fgrehm/letter_opener_web]
+  gem 'letter_opener_web'
 
   # デバッグツール pryコンソールを使えるようにする
   # [https://github.com/deivid-rodriguez/pry-byebug]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
@@ -84,6 +86,8 @@ GEM
       racc
     builder (3.3.0)
     byebug (11.1.3)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
@@ -92,6 +96,18 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    devise (4.9.4)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+    devise-i18n (1.12.1)
+      devise (>= 4.9.0)
+    devise_token_auth (1.2.5)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 8.1)
     diff-lcs (1.5.1)
     diffy (3.4.3)
     dotenv (3.1.7)
@@ -105,6 +121,8 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -129,6 +147,17 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.3)
+    launchy (3.1.0)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -160,6 +189,7 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.18.2-aarch64-linux-gnu)
       racc (~> 1.4)
+    orm_adapter (0.5.0)
     ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.7.0)
@@ -179,6 +209,7 @@ GEM
     psych (5.2.3)
       date
       stringio
+    public_suffix (6.0.1)
     puma (6.5.0)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -229,6 +260,10 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
+    responders (3.1.1)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
+    rexml (3.4.0)
     ridgepole (3.0.1)
       activerecord (>= 6.1, < 8.1)
       diffy
@@ -320,6 +355,8 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.2)
     useragent (0.16.11)
+    warden (1.2.9)
+      rack (>= 2.0.9)
     websocket-driver (0.7.7)
       base64
       websocket-extensions (>= 0.1.0)
@@ -335,8 +372,13 @@ DEPENDENCIES
   bootsnap
   brakeman
   debug
+  devise
+  devise-i18n
+  devise_token_auth
   factory_bot_rails
+  faker
   kamal
+  letter_opener_web
   mysql2 (~> 0.5)
   pry-byebug
   pry-doc

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::API
+        include DeviseTokenAuth::Concerns::SetUserByToken
+        include DeviseHackFakeSession
 end

--- a/backend/app/controllers/concerns/devise_hack_fake_session.rb
+++ b/backend/app/controllers/concerns/devise_hack_fake_session.rb
@@ -1,0 +1,24 @@
+module DeviseHackFakeSession
+  extend ActiveSupport::Concern
+
+  class FakeSession < Hash
+    def enabled?
+      false
+    end
+
+    def destroy
+    end
+  end
+
+  included do
+    before_action :set_fake_session
+
+    private
+
+      def set_fake_session
+        if Rails.configuration.respond_to?(:api_only) && Rails.configuration.api_only
+          request.env['rack.session'] ||= ::DeviseHackFakeSession::FakeSession.new
+        end
+      end
+  end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,7 +1,9 @@
-class User < ApplicationRecord
-  has_secure_password
+# frozen_string_literal: true
 
-  validates :name, presence: true, uniqueness: true
-  validates :screen_name, presence: true
-  validates :email, presence: true, uniqueness: true
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :lockable, :timeoutable, :trackable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable, :confirmable
+  include DeviseTokenAuth::Concerns::User
 end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -42,5 +42,7 @@ module Api
         controller_specs: true,
         request_specs: true
     end
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -70,4 +70,9 @@ Rails.application.configure do
 
   # RSpecリクエストホストを許可する
   config.hosts << 'www.example.com'
+
+  # 認証メール送信に関する設定
+  config.action_mailer.default_options = { from: 'no-replay@example.com' }
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.delivery_method = :letter_opener_web
 end

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+# Assuming you have not yet modified this file, each configuration option below
+# is set to its default value. Note that some are commented out while others
+# are not: uncommented lines are intended to protect your configuration from
+# breaking changes in upgrades (i.e., in the event that future versions of
+# Devise change the default values for those options).
+#
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '96b93fdbc99c73ff487857e322979d9ae202b699cfb219bf38b3beba72f2a3fd0f768b14ec2e925dbad3c374f4095f1dbbdb59d018afb24cc31659cec45a5779'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication.
+  # For API-only applications to support authentication "out-of-the-box", you will likely want to
+  # enable this with :database unless you are using a custom strategy.
+  # The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 12. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  # The number of stretches used for generating the hashed password are stored
+  # with the hashed password. This allows you to change the stretches without
+  # invalidating existing passwords.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 12
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = '478bd3d5c1d675cdbdbbd090210c2e5778e74652d341a35f6c06518434b883bff9df1cacb06541cfa45c76b878c7ac7a1cf141caaf38182e3e82fda68c7e2b4f'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+DeviseTokenAuth.setup do |config|
+  # By default the authorization headers will change after each request. The
+  # client is responsible for keeping track of the changing tokens. Change
+  # this to false to prevent the Authorization header from changing after
+  # each request.
+  config.change_headers_on_each_request = false
+
+  # By default, users will need to re-authenticate after 2 weeks. This setting
+  # determines how long tokens will remain valid after they are issued.
+  config.token_lifespan = 2.weeks
+
+  # Limiting the token_cost to just 4 in testing will increase the performance of
+  # your test suite dramatically. The possible cost value is within range from 4
+  # to 31. It is recommended to not use a value more than 10 in other environments.
+  config.token_cost = Rails.env.test? ? 4 : 10
+
+  # Sets the max number of concurrent devices per user, which is 10 by default.
+  # After this limit is reached, the oldest tokens will be removed.
+  # config.max_number_of_devices = 10
+
+  # Sometimes it's necessary to make several requests to the API at the same
+  # time. In this case, each request in the batch will need to share the same
+  # auth token. This setting determines how far apart the requests can be while
+  # still using the same auth token.
+  # config.batch_request_buffer_throttle = 5.seconds
+
+  # This route will be the prefix for all oauth2 redirect callbacks. For
+  # example, using the default '/omniauth', the github oauth2 provider will
+  # redirect successful authentications to '/omniauth/github/callback'
+  # config.omniauth_prefix = "/omniauth"
+
+  # By default sending current password is not needed for the password update.
+  # Uncomment to enforce current_password param to be checked before all
+  # attribute updates. Set it to :password if you want it to be checked only if
+  # password is updated.
+  # config.check_current_password_before_update = :attributes
+
+  # By default we will use callbacks for single omniauth.
+  # It depends on fields like email, provider and uid.
+  # config.default_callbacks = true
+
+  # Makes it possible to change the headers names
+  # config.headers_names = {
+  #   :'authorization' => 'Authorization',
+  #   :'access-token' => 'access-token',
+  #   :'client' => 'client',
+  #   :'expiry' => 'expiry',
+  #   :'uid' => 'uid',
+  #   :'token-type' => 'token-type'
+  # }
+
+  # Makes it possible to use custom uid column
+  # config.other_uid = "foo"
+
+  # By default, only Bearer Token authentication is implemented out of the box.
+  # If, however, you wish to integrate with legacy Devise authentication, you can
+  # do so by enabling this flag. NOTE: This feature is highly experimental!
+  # config.enable_standard_devise_support = false
+
+  # By default DeviseTokenAuth will not send confirmation email, even when including
+  # devise confirmable module. If you want to use devise confirmable module and
+  # send email, set it to true. (This is a setting for compatibility)
+  # config.send_confirmation_email = true
+end

--- a/backend/config/locales/devise.en.yml
+++ b/backend/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/backend/config/locales/devise.views.ja.yml
+++ b/backend/config/locales/devise.views.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   namespace :api do
     namespace :v1 do
       get 'health_check', to: 'health_check#index'
+      mount_devise_token_auth_for 'User', at: 'auth'
     end
   end
 end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -19,14 +19,28 @@ ActiveRecord::Schema[8.0].define(version: 0) do
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
-    t.string "name", default: "", null: false, comment: "ユーザー名"
-    t.string "screen_name", default: "", null: false, comment: "ユーザー表示名"
-    t.string "email", default: "", null: false, comment: "メールアドレス"
-    t.string "password_digest", null: false, comment: "パスワードのハッシュ値"
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false, null: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "nickname"
+    t.string "image"
+    t.string "email"
+    t.text "tokens"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["name"], name: "index_users_on_name", unique: true
-    t.index ["screen_name"], name: "index_users_on_screen_name"
+    t.index ["name", "uid"], name: "index_users_on_name_and_uid"
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 end

--- a/backend/db/schemas/users.schema.rb
+++ b/backend/db/schemas/users.schema.rb
@@ -3,24 +3,55 @@ create_table :users,
               charset: 'utf8mb4',
               collation: 'utf8mb4_bin',
               options: 'ENGINE=InnoDB ROW_FORMAT=DYNAMIC' do |t|
-  t.string :name,
+  ## Required
+  t.string :provider,
             null: false,
-            default: '',
-            comment: 'ユーザー名'
-  t.string :screen_name,
+            default: 'email'
+  t.string :uid,
             null: false,
-            default: '',
-            comment: 'ユーザー表示名'
-  t.string :email,
-            null: false,
-            default: '',
-            comment: 'メールアドレス'
-  t.string :password_digest,
-            null: false,
-            comment: 'パスワードのハッシュ値'
-  t.timestamps
+            default: ""
 
-  add_index :users, %i[name], unique: true
-  add_index :users, %i[screen_name]
-  add_index :users, %i[email], unique: true
+  ## Database authenticatable
+  t.string :encrypted_password,
+            null: false,
+            default: ""
+
+  ## Recoverable
+  t.string :reset_password_token
+  t.datetime :reset_password_sent_at
+  t.boolean :allow_password_change,
+             null: false,
+             default: false
+
+  ## Rememberable
+  t.datetime :remember_created_at
+
+  ## Confirmable
+  t.string :confirmation_token
+  t.datetime :confirmed_at
+  t.datetime :confirmation_sent_at
+  t.string :unconfirmed_email # Only if using reconfirmable
+
+  ## Lockable
+  # t.integer :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+  # t.string :unlock_token # Only if unlock strategy is :email or :both
+  # t.datetime :locked_at
+
+  ## User Info
+  t.string :name
+  t.string :nickname
+  t.string :image
+  t.string :email
+
+  ## Tokens
+  t.text :tokens
+
+  t.timestamps
 end
+
+add_index :users, :email, unique: true
+add_index :users, %i[uid provider], unique: true
+add_index :users, :reset_password_token, unique: true
+add_index :users, :confirmation_token, unique: true
+# add_index :users, :unlock_token, unique: true
+add_index :users, %i[name uid]

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -1,9 +1,7 @@
 FactoryBot.define do
   factory :user do
-    name { 'user_1' }
-    screen_name { 'ユーザー1' }
-    email { 'user_1@example.com' }
-    password { 'p@ssw0rd' }
-    password_confirmation { 'p@ssw0rd' }
+    email { Faker::Internet.email }
+    password { 'password' }
+    confirmed_at { nil }
   end
 end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -1,12 +1,22 @@
 RSpec.describe User, type: :model do
   describe 'validations' do
+    subject { build(:user) }
+
+    it { should validate_presence_of(:email) }
+    it { should validate_uniqueness_of(:email).case_insensitive.scoped_to(:provider) }
+    it { should validate_presence_of(:password) }
+  end
+
+  describe 'メール認証のテスト' do
     let!(:user) { create(:user) }
 
-    it { should validate_presence_of(:name) }
-    it { should validate_uniqueness_of(:name) }
-    it { should validate_presence_of(:screen_name) }
-    it { should validate_presence_of(:email) }
-    it { should validate_uniqueness_of(:email) }
-    it { should have_secure_password }
+    it '未認証のユーザーは confirmed_at が nil である' do
+      expect(user.confirmed_at).to be_nil
+    end
+
+    it 'メール認証後は confirmed_at がセットされる' do
+      user.confirm
+      expect(user.confirmed_at).not_to be_nil
+    end
   end
 end

--- a/backend/spec/requests/api/v1/auths_spec.rb
+++ b/backend/spec/requests/api/v1/auths_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe '認証API', type: :request do
+  let!(:user) { create(:user, confirmed_at: Time.current) }
+
+  describe 'POST /api/v1/auth/sign_in' do
+    it '正しいメールアドレス・パスワードでログインできる' do
+      post '/api/v1/auth/sign_in', params: { email: user.email, password: user.password }
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(response.headers['access-token']).to be_present
+        expect(response.headers['client']).to be_present
+        expect(response.headers['uid']).to be_present
+      end
+    end
+
+    it '誤ったパスワードではログインできない' do
+      post '/api/v1/auth/sign_in', params: { email: user.email, password: 'wrong_password' }
+      aggregate_failures do
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.headers['access-token']).to be_blank
+        expect(response.headers['client']).to be_blank
+        expect(response.headers['uid']).to be_blank
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/auth/sign_out' do
+    it 'ログアウトできる' do
+      delete '/api/v1/auth/sign_out', headers: user.create_new_auth_token
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(response.headers['access-token']).to be_blank
+        expect(response.headers['client']).to be_blank
+        expect(response.headers['uid']).to be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes #24 

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 認証付きUserモデルの実装
  - Gem(devise)の導入
  - usersテーブルの再作成
  - Userモデルの再作成

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- ユーザー登録
  - サインイン
  - サインアウト

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- なし

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- `POST /api/v1/auth/sign_in` を実行し、レスポンスを確認
![image](https://github.com/user-attachments/assets/6d2005fe-9fe5-4e82-86bc-626d2bbf0ee7)
![image](https://github.com/user-attachments/assets/7d5d7a68-fd66-4660-b6b5-08e72e381558)
