### PR TITLE
feat: ログインユーザーの投稿一覧・投稿詳細を取得するアクションを実装した

### DIFF
--- a/backend/app/controllers/api/v1/current/posts_controller.rb
+++ b/backend/app/controllers/api/v1/current/posts_controller.rb
@@ -1,11 +1,25 @@
 class Api::V1::Current::PostsController < Api::V1::BaseController
   before_action :authenticate_user!
 
+  # GET api/v1/current/posts
+  def index
+    posts = current_user.posts.not_unsaved.order(updated_at: :desc, id: :desc)
+    render json: posts
+  end
+
+  # GET api/v1/current/posts/:id
+  def show
+    post = current_user.posts.find(params[:id])
+    render json: post
+  end
+
+  # POST api/v1/current/posts
   def create
     unsaved_post = current_user.posts.unsaved.first || current_user.posts.create!(status: :unsaved)
     render json: unsaved_post
   end
 
+  # PATCH api/v1/current/posts/:id
   def update
     post = current_user.posts.find(params[:id])
     post.update!(post_params)

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
       namespace :current do
         resource :user, only: %i[show]
-        resources :posts, only: %i[create update]
+        resources :posts, only: %i[index show create update]
       end
       resources :posts, only: %i[index show]
     end


### PR DESCRIPTION
## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes #40

## やったこと
<!-- このプルリクで何をしたのか？ -->
- `current/posts_controller.rb` にアクションを実装した
  - indexアクション
  - showアクション

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- ログインユーザーの投稿一覧取得
- ログインユーザーの投稿詳細取得

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- なし

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- 投稿一覧取得
![image](https://github.com/user-attachments/assets/7c1863f6-d869-469e-b86b-8a1a8164ff37)

- 投稿詳細取得
![image](https://github.com/user-attachments/assets/c1133576-6db3-497e-bb5f-d4a420409831)
