### PR TITLE
feat: post一覧にページネーションを実装した

### DIFF
--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -1,11 +1,27 @@
 class Api::V1::PostsController < Api::V1::BaseController
   def index
-    posts = Post.published.order(updated_at: :desc, id: :desc).eager_load(:user)
-    render json: posts
+    posts = resolve_paginated_posts(params[:updated_at], params[:id])
+    next_keyset = posts.last ? { updated_at: posts.last.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%6N%z'), id: posts.last.id } : nil
+    render json: posts, meta: { next_keyset: next_keyset }, adapter: :json
   end
 
   def show
     post = Post.published.find(params[:id])
     render json: post
+  end
+
+  private
+
+  def resolve_paginated_posts(keyset_updated_at, keyset_id)
+    if keyset_updated_at.present? && keyset_id.present?
+      Post.published.where(
+        '(posts.updated_at < ?) OR (posts.updated_at = ? AND posts.id < ?)',
+        Time.zone.parse(keyset_updated_at),
+        Time.zone.parse(keyset_updated_at),
+        keyset_id.to_i,
+      ).order(updated_at: :desc, id: :desc).eager_load(:user).limit(Post::POSTS_PER_PAGE)
+    else
+      Post.published.order(updated_at: :desc, id: :desc).eager_load(:user).limit(Post::POSTS_PER_PAGE)
+    end
   end
 end

--- a/backend/app/models/post.rb
+++ b/backend/app/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ApplicationRecord
+  POSTS_PER_PAGE = 20
   CONTENT_MAX_LENGTH = 140
 
   enum :status, { unsaved: 10, draft: 20, published: 30 }

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -18,6 +18,8 @@ ActiveRecord::Schema[8.0].define(version: 0) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["content"], name: "index_posts_on_content", type: :fulltext
+    t.index ["created_at", "id"], name: "index_posts_on_created_at_and_id"
+    t.index ["status"], name: "index_posts_on_status"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/backend/db/schemas/posts.schema.rb
+++ b/backend/db/schemas/posts.schema.rb
@@ -16,4 +16,6 @@ create_table :posts,
   t.timestamps
 
   add_index :posts, :content, type: :fulltext
+  add_index :posts, :status
+  add_index :posts, %i[created_at id]
 end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,6 +1,8 @@
 USERS_COUNT = 2
 TOTAL_POSTS_COUNT = 30
 POST_BATCH_SIZE = 1000
+FAKER_RANDOM_NUM = 42
+Faker::Config.random = Random.new(FAKER_RANDOM_NUM)
 
 users = []
 USERS_COUNT.times do |i|


### PR DESCRIPTION
## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes #37 

## やったこと
<!-- このプルリクで何をしたのか？ -->
- PostsController の index アクションにページネーションを実装した

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- ページングされた投稿一覧の取得

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- 投稿一覧での投稿全取得

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 最終的に無限スクロール実装を想定しているため、ページを戻る機能は実装していない

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- 投稿一覧の取得
![image](https://github.com/user-attachments/assets/51ef88f1-3908-4815-80b0-3fc2da851748)
![image](https://github.com/user-attachments/assets/6acd4b46-c5fb-4146-8286-a5cab6a8194f)
- 2ページ目の取得
![image](https://github.com/user-attachments/assets/4de2fba3-6587-423e-b1e8-6269ce21c205)
![image](https://github.com/user-attachments/assets/71596fdb-d86b-4d4c-be0e-332ebba87138)
