### PR TITLE
feat: サインイン操作時の成否通知バーを実装した

### DIFF
--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -11,11 +11,15 @@ import SignOut from './pages/sign_out'
 // ヘッダー
 import Header from './components/Header'
 
+// 通知バー
+import Snackbar from './components/Snackbar'
+
 function App() {
   return (
     <Router>
       <CurrentUserFetch />
       <Header />
+      <Snackbar />
 
       <Routes>
         {/* ホームページ */}

--- a/frontend/app/src/components/Snackbar.tsx
+++ b/frontend/app/src/components/Snackbar.tsx
@@ -1,0 +1,47 @@
+import { Snackbar, Alert } from '@mui/material'
+import { useEffect, useState } from 'react'
+import { useSnackbarState } from '../hooks/useGlobalState'
+
+const SuccessSnackbar = () => {
+  const [snackbar, setSnackbar] = useSnackbarState()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (snackbar.message) {
+      setOpen(true)
+    }
+  }, [snackbar.message])
+
+  const handleClose = (
+    _event: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
+    if (reason === 'clickaway') {
+      return
+    }
+    setOpen(false)
+    setSnackbar({
+      message: null,
+      severity: null,
+      pathname: null,
+    })
+  }
+
+  return (
+    <>
+      {snackbar.severity != null && (
+        <Snackbar open={open} autoHideDuration={2000} onClose={handleClose}>
+          <Alert
+            onClose={handleClose}
+            severity={snackbar.severity}
+            sx={{ width: '100%' }}
+          >
+            {snackbar.message}
+          </Alert>
+        </Snackbar>
+      )}
+    </>
+  )
+}
+
+export default SuccessSnackbar

--- a/frontend/app/src/hooks/useGlobalState.ts
+++ b/frontend/app/src/hooks/useGlobalState.ts
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import { UserStateType } from '../types/userStateType'
+import { SnackbarStateType } from '../types/snackbarStateType'
 
 export const useUserState = () => {
   const fallbackData: UserStateType = {
@@ -14,4 +15,20 @@ export const useUserState = () => {
     fallbackData: fallbackData,
   })
   return [state, setState] as [UserStateType, (value: UserStateType) => void]
+}
+
+export const useSnackbarState = () => {
+  const fallbackData: SnackbarStateType = {
+    message: null,
+    severity: null,
+    pathname: null,
+  }
+
+  const { data: state, mutate: setState } = useSWR('snackbar', null, {
+    fallbackData: fallbackData,
+  })
+  return [state, setState] as [
+    SnackbarStateType,
+    (value: SnackbarStateType) => void,
+  ]
 }

--- a/frontend/app/src/hooks/useSignIn.ts
+++ b/frontend/app/src/hooks/useSignIn.ts
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import axios from 'axios'
 import { useNavigate } from 'react-router-dom'
-import { useUserState } from './useGlobalState'
+import { useUserState, useSnackbarState } from './useGlobalState'
 import { SignInFormData } from '../types/signInFormData'
 
 export const useSignIn = () => {
   const [isLoading, setIsLoading] = useState(false)
   const [user, setUser] = useUserState()
+  const [, setSnackbar] = useSnackbarState()
   const navigate = useNavigate()
 
   const signIn = async (data: SignInFormData) => {
@@ -26,9 +27,19 @@ export const useSignIn = () => {
         ...(user ?? {}),
         isFetched: false,
       })
+      setSnackbar({
+        message: 'サインインに成功しました',
+        severity: 'success',
+        pathname: '/posts',
+      })
       navigate('/posts')
     } catch (error) {
       console.error('Sign-in error:', error)
+      setSnackbar({
+        message: '登録ユーザーが見つかりません',
+        severity: 'error',
+        pathname: '/sign-in',
+      })
     } finally {
       setIsLoading(false)
     }

--- a/frontend/app/src/types/post.ts
+++ b/frontend/app/src/types/post.ts
@@ -1,4 +1,4 @@
-export interface Post {
+export type Post = {
   id: number
   content: string
   status: string

--- a/frontend/app/src/types/postsResponse.ts
+++ b/frontend/app/src/types/postsResponse.ts
@@ -1,6 +1,6 @@
 import { Post } from './post'
 
-export interface PostsResponse {
+export type PostsResponse = {
   posts: Post[]
   meta: {
     next_keyset?: {

--- a/frontend/app/src/types/signInFormData.ts
+++ b/frontend/app/src/types/signInFormData.ts
@@ -1,4 +1,4 @@
-export interface SignInFormData {
+export type SignInFormData = {
   email: string
   password: string
 }

--- a/frontend/app/src/types/snackbarStateType.ts
+++ b/frontend/app/src/types/snackbarStateType.ts
@@ -1,0 +1,5 @@
+export type SnackbarStateType = {
+  message: null | string
+  severity: null | 'success' | 'error'
+  pathname: null | string
+}

--- a/frontend/app/src/types/userStateType.ts
+++ b/frontend/app/src/types/userStateType.ts
@@ -1,4 +1,4 @@
-export interface UserStateType {
+export type UserStateType = {
   id: number
   name: string
   email: string


### PR DESCRIPTION
## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes #51

## やったこと
<!-- このプルリクで何をしたのか？ -->
- サインイン操作時の成否通知バーの実装

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- サインインの成功・失敗がわかる

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- なし

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- サインイン成功時

https://github.com/user-attachments/assets/99643224-c44f-4ba3-9d99-4091053fa550


- サインイン失敗時

https://github.com/user-attachments/assets/840a2035-19f4-4270-ae72-a862de27f83d

