### PR TITLE
feat: 投稿詳細ページを実装した

### DIFF
--- a/backend/app/serializers/post_serializer.rb
+++ b/backend/app/serializers/post_serializer.rb
@@ -3,7 +3,7 @@ class PostSerializer < ActiveModel::Serializer
   belongs_to :user, serializer: UserSerializer
 
   def created_at
-    object.created_at.strftime('%Y-%m-%d')
+    object.created_at.strftime('%Y年%m月%d日 %H時%M分%S秒')
   end
 
   def from_today

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -6,6 +6,7 @@ import CurrentPosts from './pages/current/posts'
 import Home from './pages/home'
 import HealthCheck from './pages/health_check'
 import Index from './pages/index'
+import PostDetail from './pages/posts/[id]'
 import SignIn from './pages/sign_in'
 import SignOut from './pages/sign_out'
 
@@ -31,6 +32,8 @@ function App() {
         <Route path="/health-check" element={<HealthCheck />} />{' '}
         {/* 投稿一覧ページ */}
         <Route path="/posts" element={<Index />} />
+        {/* 投稿詳細ページ */}
+        <Route path="/posts/:id" element={<PostDetail />} />
         {/* サインインページ */}
         <Route path="/sign-in" element={<SignIn />} />
         {/* サインアウトページ */}

--- a/frontend/app/src/components/Error.tsx
+++ b/frontend/app/src/components/Error.tsx
@@ -1,0 +1,17 @@
+import { Card, CardContent, Container } from '@mui/material'
+
+const Error = () => {
+  return (
+    <Container maxWidth="sm">
+      <Card sx={{ p: 3, mt: 8, backgroundColor: '#EEE' }}>
+        <CardContent sx={{ lineHeight: 2 }}>
+          <p>
+            現在、システムに技術的な問題が発生しています。ご不便をおかけして申し訳ありませんが、復旧までしばらくお待ちください。
+          </p>
+        </CardContent>
+      </Card>
+    </Container>
+  )
+}
+
+export default Error

--- a/frontend/app/src/components/PostDetailItem.tsx
+++ b/frontend/app/src/components/PostDetailItem.tsx
@@ -1,0 +1,50 @@
+// 投稿詳細を表示するコンポーネント
+import { Box, Card, CardContent, Typography } from '@mui/material'
+import { Post } from '@/types/post'
+
+type PostDetailProps = {
+  post: Post | null
+}
+
+const PostDetailItem: React.FC<PostDetailProps> = ({ post }) => {
+  if (!post) return <p>投稿が見つかりませんでした</p>
+
+  return (
+    <Card>
+      <CardContent>
+        <Typography
+          component={'h3'}
+          sx={{
+            mb: 2,
+            minHeight: 20,
+            fontSize: 16,
+            fontWeight: 'bold',
+            lineHeight: 1.5,
+          }}
+        >
+          {post.user.name}
+        </Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div className="border p-4 mb-2 rounded shadow">
+            <Typography sx={{ fontSize: 14 }}>{post.content}</Typography>
+            <Typography sx={{ fontSize: 12 }}>
+              初回投稿：{post.createdAt}
+            </Typography>
+            <Typography sx={{ fontSize: 12 }}>
+              最終更新：{post.fromToday}
+            </Typography>
+
+            {/* ↓↓↓ デバッグ用 最後に消す ↓↓↓ */}
+            <Typography sx={{ fontSize: 12 }}>post.id: {post.id}</Typography>
+            <Typography sx={{ fontSize: 12 }}>
+              post.status: {post.status}
+            </Typography>
+            {/* ↑↑↑ デバッグ用 最後に消す ↑↑↑ */}
+          </div>
+        </Box>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default PostDetailItem

--- a/frontend/app/src/components/PostItem.tsx
+++ b/frontend/app/src/components/PostItem.tsx
@@ -1,5 +1,5 @@
 // 投稿アイテムを表示するコンポーネント
-import React from 'react'
+import { Link } from 'react-router-dom'
 import { Box, Card, CardContent, Typography } from '@mui/material'
 import { Post } from '@/types/post'
 
@@ -9,37 +9,39 @@ type PostItemProps = {
 
 const PostItem: React.FC<PostItemProps> = ({ post }) => {
   return (
-    <Card>
-      <CardContent>
-        <Typography
-          component={'h3'}
-          sx={{
-            mb: 2,
-            minHeight: 20,
-            fontSize: 16,
-            fontWeight: 'bold',
-            lineHeight: 1.5,
-          }}
-        >
-          {post.user.name}
-        </Typography>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-          <div className="border p-4 mb-2 rounded shadow">
-            <Typography sx={{ fontSize: 14 }}>{post.content}</Typography>
-            <Typography sx={{ fontSize: 12 }}>
-              最終更新：{post.fromToday}
-            </Typography>
+    <Link to={`/posts/${post.id}`}>
+      <Card>
+        <CardContent>
+          <Typography
+            component={'h3'}
+            sx={{
+              mb: 2,
+              minHeight: 20,
+              fontSize: 16,
+              fontWeight: 'bold',
+              lineHeight: 1.5,
+            }}
+          >
+            {post.user.name}
+          </Typography>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <div className="border p-4 mb-2 rounded shadow">
+              <Typography sx={{ fontSize: 14 }}>{post.content}</Typography>
+              <Typography sx={{ fontSize: 12 }}>
+                最終更新：{post.fromToday}
+              </Typography>
 
-            {/* ↓↓↓ デバッグ用 最後に消す ↓↓↓ */}
-            <Typography sx={{ fontSize: 12 }}>post.id: {post.id}</Typography>
-            <Typography sx={{ fontSize: 12 }}>
-              post.status: {post.status}
-            </Typography>
-            {/* ↑↑↑ デバッグ用 最後に消す ↑↑↑ */}
-          </div>
-        </Box>
-      </CardContent>
-    </Card>
+              {/* ↓↓↓ デバッグ用 最後に消す ↓↓↓ */}
+              <Typography sx={{ fontSize: 12 }}>post.id: {post.id}</Typography>
+              <Typography sx={{ fontSize: 12 }}>
+                post.status: {post.status}
+              </Typography>
+              {/* ↑↑↑ デバッグ用 最後に消す ↑↑↑ */}
+            </div>
+          </Box>
+        </CardContent>
+      </Card>
+    </Link>
   )
 }
 

--- a/frontend/app/src/components/PostList.tsx
+++ b/frontend/app/src/components/PostList.tsx
@@ -13,7 +13,7 @@ const PostList: React.FC<PostListProps> = ({ posts }) => {
     <Grid container spacing={3}>
       {posts.map((post) => (
         <Grid item xs={12} key={post.id}>
-          <PostItem key={`${post.id}`} post={post} />
+          <PostItem post={post} />
         </Grid>
       ))}
     </Grid>

--- a/frontend/app/src/hooks/useFetchPostDetail.ts
+++ b/frontend/app/src/hooks/useFetchPostDetail.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import { fetcher } from '@/utils'
+import { Post } from '@/types/post'
+
+export const useFetchPostDetail = (apiPath: string) => {
+  const { id } = useParams<{ id: string }>()
+  const [post, setPost] = useState<Post | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+
+    const fetchPostDetail = async () => {
+      try {
+        const data = await fetcher(`${apiPath}/${id.toString()}`)
+        setPost(data)
+      } catch (error) {
+        console.error('Error loading post detail:', error)
+        setError('ポストの取得に失敗しました')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchPostDetail()
+  }, [apiPath, id])
+
+  return { post, loading, error }
+}

--- a/frontend/app/src/main.tsx
+++ b/frontend/app/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './styles/index'
+import './styles/destyle.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/app/src/pages/index.tsx
+++ b/frontend/app/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { Box, CircularProgress, Container, Typography } from '@mui/material'
 import PostList from '@/components/PostList'
+import Error from '@/components/Error'
 import Loader from '@/components/Loader'
 import { useFetchPosts } from '@/hooks/useFetchPosts'
 import useInfiniteScroll from '@/hooks/useInfiniteScroll'
@@ -11,7 +12,7 @@ const Index = () => {
 
   const { triggerRef } = useInfiniteScroll(loadMorePosts, hasMore)
 
-  if (error) return <div>エラーが発生しました。</div>
+  if (error) return <Error />
   if (loading) return <Loader />
 
   return (

--- a/frontend/app/src/pages/posts/[id].tsx
+++ b/frontend/app/src/pages/posts/[id].tsx
@@ -1,0 +1,38 @@
+import { Box, Container, Typography } from '@mui/material'
+import { styles } from '@/styles'
+import Error from '@/components/Error'
+import Loader from '@/components/Loader'
+import { useFetchPostDetail } from '@/hooks/useFetchPostDetail'
+import PostDetailItem from '@/components/PostDetailItem'
+
+const PostDetail = () => {
+  const { post, loading, error } = useFetchPostDetail('/posts')
+
+  if (error) return <Error />
+  if (loading) return <Loader />
+
+  return (
+    <Box sx={(styles.pageMinHeight, { backgroundColor: '#E6F2FF' })}>
+      <Container maxWidth="md" sx={{ pt: 6 }}>
+        <Typography
+          component="h1"
+          sx={{
+            mb: 2,
+            fontSize: 24,
+            fontWeight: 'bold',
+            lineHeight: 1.5,
+            color: 'black',
+          }}
+        >
+          投稿詳細
+        </Typography>
+        <div>
+          {/* 投稿データの表示 */}
+          <PostDetailItem key={`${post?.id}`} post={post} />
+        </div>
+      </Container>
+    </Box>
+  )
+}
+
+export default PostDetail

--- a/frontend/app/src/styles/destyle.css
+++ b/frontend/app/src/styles/destyle.css
@@ -1,0 +1,416 @@
+/*! destyle.css v4.0.1 | MIT License | https://github.com/nicolas-cusan/destyle.css */
+
+/* Reset box-model and set borders */
+/* ============================================ */
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  border-style: solid;
+  border-width: 0;
+  min-width: 0;
+}
+
+/* Document */
+/* ============================================ */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ * 3. Remove gray overlay on links for iOS.
+ */
+
+html {
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+  -webkit-tap-highlight-color: transparent; /* 3*/
+}
+
+/* Sections */
+/* ============================================ */
+
+/**
+ * Remove the margin in all browsers.
+ */
+
+body {
+  margin: 0;
+}
+
+/**
+ * Render the `main` element consistently in IE.
+ */
+
+main {
+  display: block;
+}
+
+/* Vertical rhythm */
+/* ============================================ */
+
+p,
+table,
+blockquote,
+address,
+pre,
+iframe,
+form,
+figure,
+dl {
+  margin: 0;
+}
+
+/* Headings */
+/* ============================================ */
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+  margin: 0;
+}
+
+/* Lists (enumeration) */
+/* ============================================ */
+
+ul,
+ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Lists (definition) */
+/* ============================================ */
+
+dt {
+  font-weight: bold;
+}
+
+dd {
+  margin-left: 0;
+}
+
+/* Grouping content */
+/* ============================================ */
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+  border-top-width: 1px;
+  margin: 0;
+  clear: both;
+  color: inherit;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: inherit; /* 2 */
+}
+
+address {
+  font-style: inherit;
+}
+
+/* Text-level semantics */
+/* ============================================ */
+
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+  text-decoration: none;
+  color: inherit;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: inherit; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Replaced content */
+/* ============================================ */
+
+/**
+ * Prevent vertical alignment issues.
+ */
+
+svg,
+img,
+embed,
+object,
+iframe {
+  vertical-align: bottom;
+}
+
+/* Forms */
+/* ============================================ */
+
+/**
+ * Reset form fields to make them styleable.
+ * 1. Make form elements stylable across systems iOS especially.
+ * 2. Inherit text-transform from parent.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  -webkit-appearance: none; /* 1 */
+  appearance: none;
+  vertical-align: middle;
+  color: inherit;
+  font: inherit;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  border-radius: 0;
+  text-align: inherit;
+  text-transform: inherit; /* 2 */
+}
+
+/**
+ * Correct cursors for clickable elements.
+ */
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  cursor: pointer;
+}
+
+button:disabled,
+[type='button']:disabled,
+[type='reset']:disabled,
+[type='submit']:disabled {
+  cursor: default;
+}
+
+/**
+ * Improve outlines for Firefox and unify style with input elements & buttons.
+ */
+
+:-moz-focusring {
+  outline: auto;
+}
+
+select:disabled {
+  opacity: inherit;
+}
+
+/**
+ * Remove padding
+ */
+
+option {
+  padding: 0;
+}
+
+/**
+ * Reset to invisible
+ */
+
+fieldset {
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+legend {
+  padding: 0;
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * Correct the outline style in Safari.
+ */
+
+[type='search'] {
+  outline-offset: -2px; /* 1 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+
+[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Fix font inheritance.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/**
+ * Fix appearance for Firefox
+ */
+[type='number'] {
+  -moz-appearance: textfield;
+  appearance: none;
+}
+
+/**
+ * Clickable labels
+ */
+
+label[for] {
+  cursor: pointer;
+}
+
+/* Interactive */
+/* ============================================ */
+
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+
+details {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/*
+ * Remove outline for editable content.
+ */
+
+[contenteditable]:focus {
+  outline: auto;
+}
+
+/* Tables */
+/* ============================================ */
+
+/**
+1. Correct table border color inheritance in all Chrome and Safari.
+*/
+
+table {
+  border-color: inherit; /* 1 */
+  border-collapse: collapse;
+}
+
+caption {
+  text-align: left;
+}
+
+td,
+th {
+  vertical-align: top;
+  padding: 0;
+}
+
+th {
+  text-align: left;
+  font-weight: bold;
+}


### PR DESCRIPTION
## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes #56

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 投稿詳細ページの作成
  - 投稿一覧ページから各投稿詳細ページへ遷移できるよう設定

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- 投稿詳細の表示

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- なし

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 今後、投稿一覧へ戻った際の挙動について検討する
  - スクロール位置の記録と復元
    - ページを離れる際にsessionStorageに保存し、期間時に読み込む機能を検討中
  - 投稿データの記録と復元
    - useSWRInfiniteの使用を検討中

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- 投稿詳細ページの表示
https://github.com/user-attachments/assets/5cbfa10f-4a16-488f-a081-8ee21f46d112

