### PR TITLE
refactor: useSWRInfiniteを使った無限スクロールと、スクロール位置の復元を実装した

### DIFF
--- a/frontend/app/src/components/Header.tsx
+++ b/frontend/app/src/components/Header.tsx
@@ -29,6 +29,10 @@ const Header = () => {
   const handleClose = () => {
     setAnchorEl(null)
   }
+  const handleClickLogo = (event: React.MouseEvent) => {
+    event.preventDefault() // リンクのデフォルトの挙動を無効化
+    window.location.href = '/posts'
+  }
 
   return (
     <AppBar
@@ -49,7 +53,7 @@ const Header = () => {
           }}
         >
           <Box>
-            <Link to="/posts">
+            <Link to="/posts" onClick={handleClickLogo}>
               <img src="/logo.png" alt="logo" width={150} height={40} />
             </Link>
           </Box>

--- a/frontend/app/src/components/PostItem.tsx
+++ b/frontend/app/src/components/PostItem.tsx
@@ -8,8 +8,13 @@ type PostItemProps = {
 }
 
 const PostItem: React.FC<PostItemProps> = ({ post }) => {
+  // 投稿クリック時にscrollPosition をセッションストレージに保存
+  const handleClick = () => {
+    sessionStorage.setItem('scrollPosition', window.scrollY.toString())
+  }
+
   return (
-    <Link to={`/posts/${post.id}`}>
+    <Link to={`/posts/${post.id}`} onClick={handleClick}>
       <Card>
         <CardContent>
           <Typography

--- a/frontend/app/src/hooks/useSavedScrollPosition.ts
+++ b/frontend/app/src/hooks/useSavedScrollPosition.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+
+const useSavedScrollPosition = (
+  isInitialLoading: boolean,
+  isFetchingMore: boolean
+) => {
+  useEffect(() => {
+    if (isInitialLoading) {
+      sessionStorage.removeItem('scrollPosition')
+      return
+    }
+    if (isFetchingMore) return
+
+    const savedScrollPosition = sessionStorage.getItem('scrollPosition')
+    if (savedScrollPosition) {
+      window.scrollTo(0, parseInt(savedScrollPosition))
+      sessionStorage.removeItem('scrollPosition')
+    }
+  }, [isInitialLoading, isFetchingMore])
+}
+
+export default useSavedScrollPosition

--- a/frontend/app/src/pages/current/posts.tsx
+++ b/frontend/app/src/pages/current/posts.tsx
@@ -11,14 +11,20 @@ const CurrentPosts = () => {
   useRequireSignedIn()
   const [user] = useUserState()
 
-  const { postData, error, loading, loadMorePosts, isLoadingMore, hasMore } =
-    useFetchPosts('/current/posts')
+  const {
+    postData,
+    error,
+    isInitialLoading,
+    isFetchingMore,
+    loadMorePosts,
+    hasMore,
+  } = useFetchPosts('/current/posts')
 
   const { triggerRef } = useInfiniteScroll(loadMorePosts, hasMore)
 
   if (!user.isSignedIn) return <div>サインインが必要です。</div>
   if (error) return <div>エラーが発生しました。</div>
-  if (loading) return <Loader />
+  if (isInitialLoading) return <Loader />
 
   return (
     <Box sx={styles.pageMinHeight}>
@@ -37,10 +43,10 @@ const CurrentPosts = () => {
         </Typography>
         <div>
           {/* 投稿データの表示 */}
-          {<CurrentPostList posts={postData.posts} />}
+          {<CurrentPostList posts={postData} />}
 
           {/* ローディング表示 */}
-          {hasMore && isLoadingMore && (
+          {hasMore && isFetchingMore && (
             <CircularProgress
               sx={{
                 margin: 'auto',

--- a/frontend/app/src/pages/index.tsx
+++ b/frontend/app/src/pages/index.tsx
@@ -5,15 +5,23 @@ import Loader from '@/components/Loader'
 import { useFetchPosts } from '@/hooks/useFetchPosts'
 import useInfiniteScroll from '@/hooks/useInfiniteScroll'
 import { styles } from '@/styles'
+import useSavedScrollPosition from '@/hooks/useSavedScrollPosition'
 
 const Index = () => {
-  const { postData, error, loading, loadMorePosts, isLoadingMore, hasMore } =
-    useFetchPosts('/posts')
+  const {
+    postData,
+    error,
+    isInitialLoading,
+    isFetchingMore,
+    loadMorePosts,
+    hasMore,
+  } = useFetchPosts('/posts')
 
   const { triggerRef } = useInfiniteScroll(loadMorePosts, hasMore)
+  useSavedScrollPosition(isInitialLoading, isFetchingMore)
 
   if (error) return <Error />
-  if (loading) return <Loader />
+  if (isInitialLoading) return <Loader />
 
   return (
     <Box sx={(styles.pageMinHeight, { backgroundColor: '#E6F2FF' })}>
@@ -32,10 +40,10 @@ const Index = () => {
         </Typography>
         <div>
           {/* 投稿データの表示 */}
-          {<PostList posts={postData.posts} />}
+          {<PostList posts={postData} />}
 
           {/* ローディング表示 */}
-          {hasMore && isLoadingMore && (
+          {hasMore && isFetchingMore && (
             <CircularProgress
               sx={{
                 margin: 'auto',


### PR DESCRIPTION
## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes #58

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 無限スクロールにuseSWRInfiniteを導入する
- 投稿一覧 → 投稿詳細 → 投稿一覧と遷移したとき、一覧ページのスクロール位置復元機能を実装した

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- 投稿一覧ページでのスクロール位置復元

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- 自動で投稿データを更新すること

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ブラウザバックで戻る場合：スクロール位置復元
- ロゴクリックで投稿一覧表示：リロードが走り、最上部が表示される

https://github.com/user-attachments/assets/fb8b3584-51cf-44fc-b693-33f96b8068f7

