### PR TITLE
feat: サインインユーザーの投稿詳細ページを作成した

### DIFF
--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -11,6 +11,8 @@ module Api
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 
+    config.active_record.default_timezone = :local
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
@@ -45,5 +47,7 @@ module Api
 
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.yml').to_s]
+
+    config.time_zone = 'Asia/Tokyo'
   end
 end

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -3,6 +3,7 @@ import CurrentUserFetch from './components/CurrentUserFetch'
 
 // Route
 import CurrentPosts from './pages/current/posts'
+import CurrentPostDetail from './pages/current/posts/[id]'
 import Home from './pages/home'
 import HealthCheck from './pages/health_check'
 import Index from './pages/index'
@@ -28,6 +29,8 @@ function App() {
         <Route path="/" element={<Home />} />
         {/* サインインユーザー投稿一覧 */}
         <Route path="/current/posts" element={<CurrentPosts />} />
+        {/* サインインユーザー投稿詳細 */}
+        <Route path="/current/posts/:id" element={<CurrentPostDetail />} />
         {/* ヘルスチェック */}
         <Route path="/health-check" element={<HealthCheck />} />{' '}
         {/* 投稿一覧ページ */}

--- a/frontend/app/src/components/CurrentPostItem.tsx
+++ b/frontend/app/src/components/CurrentPostItem.tsx
@@ -4,12 +4,21 @@ import EditIcon from '@mui/icons-material/Edit'
 import { Avatar, Box, IconButton, Tooltip, Typography } from '@mui/material'
 import React from 'react'
 import { Post } from '@/types/post'
+import { Link } from 'react-router-dom'
 
 type PostItemProps = {
   post: Post
 }
 
 const CurrentPostItem: React.FC<PostItemProps> = ({ post }) => {
+  // 投稿クリック時にscrollPosition をセッションストレージに保存
+  const handleClick = () => {
+    sessionStorage.setItem(
+      'scrollPositionCurrentPosts',
+      window.scrollY.toString()
+    )
+  }
+
   return (
     <Box
       sx={{
@@ -90,9 +99,11 @@ const CurrentPostItem: React.FC<PostItemProps> = ({ post }) => {
         <Box>
           <Avatar>
             <Tooltip title="表示を確認">
-              <IconButton sx={{ backgroundColor: '#F1F5FA' }}>
-                <ChevronRightIcon sx={{ color: '#99AAB6' }} />
-              </IconButton>
+              <Link to={`/current/posts/${post.id}`} onClick={handleClick}>
+                <IconButton sx={{ backgroundColor: '#F1F5FA' }}>
+                  <ChevronRightIcon sx={{ color: '#99AAB6' }} />
+                </IconButton>
+              </Link>
             </Tooltip>
           </Avatar>
         </Box>

--- a/frontend/app/src/components/DebugPostDetail.tsx
+++ b/frontend/app/src/components/DebugPostDetail.tsx
@@ -1,0 +1,55 @@
+// 投稿詳細にデバッグ用データを表示するコンポーネント（最後に消すこと）
+import { Box, Card, List, ListItem, ListItemText } from '@mui/material'
+import { Post } from '@/types/post'
+
+type PostDetailProps = {
+  post: Post | null
+}
+const DebugPostDetail: React.FC<PostDetailProps> = ({ post }) => {
+  return (
+    <Box sx={{ display: 'flex', gap: '0 24px', pt: 3 }}>
+      <Box sx={{ width: '100%' }}>
+        <Card
+          sx={{
+            backgroundColor: '#AAA',
+            backShadow: 'none',
+            borderRadius: '12px',
+            maxWidth: 840,
+            m: '0 auto',
+          }}
+        >
+          <Box
+            sx={{
+              p: 3,
+            }}
+          >
+            <List>
+              <ListItem divider>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  <Box sx={{ pr: 1 }}>
+                    <ListItemText primary="投稿ID（デバッグ用）" />
+                  </Box>
+                  <Box>
+                    <ListItemText primary={post?.id} />
+                  </Box>
+                </Box>
+              </ListItem>
+              <ListItem>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  <Box sx={{ pr: 1 }}>
+                    <ListItemText primary="投稿ステータス（デバッグ用）" />
+                  </Box>
+                  <Box>
+                    <ListItemText primary={post?.status} />
+                  </Box>
+                </Box>
+              </ListItem>
+            </List>
+          </Box>
+        </Card>
+      </Box>
+    </Box>
+  )
+}
+
+export default DebugPostDetail

--- a/frontend/app/src/components/Header.tsx
+++ b/frontend/app/src/components/Header.tsx
@@ -29,9 +29,17 @@ const Header = () => {
   const handleClose = () => {
     setAnchorEl(null)
   }
+
+  // ロゴクリック時、投稿一覧をフルリロードする
   const handleClickLogo = (event: React.MouseEvent) => {
     event.preventDefault() // リンクのデフォルトの挙動を無効化
     window.location.href = '/posts'
+  }
+
+  // アイコンクリック時、サインインユーザーの投稿一覧をフルリロードする
+  const handleClickCurrentPosts = (event: React.MouseEvent) => {
+    event.preventDefault() // リンクのデフォルトの挙動を無効化
+    window.location.href = '/current/posts'
   }
 
   return (
@@ -131,7 +139,11 @@ const Header = () => {
                       </Typography>
                     </Box>
                     <Divider />
-                    <MenuItem component={Link} to="/current/posts">
+                    <MenuItem
+                      component={Link}
+                      to="/current/posts"
+                      onClick={handleClickCurrentPosts}
+                    >
                       <ListItemIcon>
                         <ArticleIcon fontSize="small" />
                       </ListItemIcon>

--- a/frontend/app/src/components/PostDetailItem.tsx
+++ b/frontend/app/src/components/PostDetailItem.tsx
@@ -1,6 +1,17 @@
 // 投稿詳細を表示するコンポーネント
-import { Box, Card, CardContent, Typography } from '@mui/material'
+import { Update } from '@mui/icons-material'
+import ArticleIcon from '@mui/icons-material/Article'
+import {
+  Box,
+  Card,
+  Container,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+} from '@mui/material'
 import { Post } from '@/types/post'
+import DebugPostDetail from './DebugPostDetail'
 
 type PostDetailProps = {
   post: Post | null
@@ -10,40 +21,96 @@ const PostDetailItem: React.FC<PostDetailProps> = ({ post }) => {
   if (!post) return <p>投稿が見つかりませんでした</p>
 
   return (
-    <Card>
-      <CardContent>
-        <Typography
-          component={'h3'}
+    <Container maxWidth="lg">
+      <Box sx={{ pt: 6, pb: 3 }}>
+        <Box
           sx={{
-            mb: 2,
-            minHeight: 20,
-            fontSize: 16,
-            fontWeight: 'bold',
-            lineHeight: 1.5,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0 8px',
+            m: 'auto',
           }}
         >
-          {post.user.name}
-        </Typography>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-          <div className="border p-4 mb-2 rounded shadow">
-            <Typography sx={{ fontSize: 14 }}>{post.content}</Typography>
-            <Typography sx={{ fontSize: 12 }}>
-              初回投稿：{post.createdAt}
+          <Box sx={{ textAlign: 'center', width: '100%' }}>
+            <Typography
+              component="h2"
+              sx={{
+                fontSize: { xs: 21, sm: 25 },
+                fontWeight: 'bold',
+                lineHeight: '40px',
+              }}
+            >
+              {post?.user.name} さんの投稿
             </Typography>
-            <Typography sx={{ fontSize: 12 }}>
-              最終更新：{post.fromToday}
-            </Typography>
-
-            {/* ↓↓↓ デバッグ用 最後に消す ↓↓↓ */}
-            <Typography sx={{ fontSize: 12 }}>post.id: {post.id}</Typography>
-            <Typography sx={{ fontSize: 12 }}>
-              post.status: {post.status}
-            </Typography>
-            {/* ↑↑↑ デバッグ用 最後に消す ↑↑↑ */}
-          </div>
+          </Box>
         </Box>
-      </CardContent>
-    </Card>
+      </Box>
+      <Box sx={{ display: 'flex', gap: '0 24px' }}>
+        <Box sx={{ width: '100%' }}>
+          <Card
+            sx={{
+              backShadow: 'none',
+              borderRadius: '12px',
+              maxWidth: 840,
+              m: '0 auto',
+            }}
+          >
+            <Box
+              sx={{
+                p: 3,
+              }}
+            >
+              <p>{post?.content}</p>
+            </Box>
+            <List sx={{ color: '#6E7B85' }}>
+              <ListItem divider>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    width: '100%',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <Box sx={{ pr: 1 }}>
+                      <ArticleIcon />
+                    </Box>
+                    <ListItemText primary="初回投稿" />
+                  </Box>
+                  <Box>
+                    <ListItemText primary={post?.createdAt} />
+                  </Box>
+                </Box>
+              </ListItem>
+              <ListItem>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    width: '100%',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <Box sx={{ pr: 1 }}>
+                      <Update />
+                    </Box>
+                    <ListItemText primary="最終更新" />
+                  </Box>
+                  <Box>
+                    <ListItemText primary={post?.fromToday} />
+                  </Box>
+                </Box>
+              </ListItem>
+            </List>
+          </Card>
+        </Box>
+      </Box>
+      {/* ↓↓↓ デバッグ用 最後に消す ↓↓↓ */}
+      <DebugPostDetail post={post} />
+      {/* ↑↑↑ デバッグ用 最後に消す ↑↑↑ */}
+    </Container>
   )
 }
 

--- a/frontend/app/src/components/PostItem.tsx
+++ b/frontend/app/src/components/PostItem.tsx
@@ -10,7 +10,7 @@ type PostItemProps = {
 const PostItem: React.FC<PostItemProps> = ({ post }) => {
   // 投稿クリック時にscrollPosition をセッションストレージに保存
   const handleClick = () => {
-    sessionStorage.setItem('scrollPosition', window.scrollY.toString())
+    sessionStorage.setItem('scrollPositionPosts', window.scrollY.toString())
   }
 
   return (

--- a/frontend/app/src/hooks/useFetchPostDetail.ts
+++ b/frontend/app/src/hooks/useFetchPostDetail.ts
@@ -1,20 +1,18 @@
 import { useState, useEffect } from 'react'
-import { useParams } from 'react-router-dom'
 import { fetcher } from '@/utils'
 import { Post } from '@/types/post'
 
-export const useFetchPostDetail = (apiPath: string) => {
-  const { id } = useParams<{ id: string }>()
+export const useFetchPostDetail = (apiPath: string | null) => {
   const [post, setPost] = useState<Post | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!id) return
+    if (!apiPath) return
 
     const fetchPostDetail = async () => {
       try {
-        const data = await fetcher(`${apiPath}/${id.toString()}`)
+        const data = await fetcher(apiPath)
         setPost(data)
       } catch (error) {
         console.error('Error loading post detail:', error)
@@ -25,7 +23,7 @@ export const useFetchPostDetail = (apiPath: string) => {
     }
 
     fetchPostDetail()
-  }, [apiPath, id])
+  }, [apiPath])
 
   return { post, loading, error }
 }

--- a/frontend/app/src/hooks/useSavedScrollPosition.ts
+++ b/frontend/app/src/hooks/useSavedScrollPosition.ts
@@ -2,21 +2,22 @@ import { useEffect } from 'react'
 
 const useSavedScrollPosition = (
   isInitialLoading: boolean,
-  isFetchingMore: boolean
+  isFetchingMore: boolean,
+  keyName: string
 ) => {
   useEffect(() => {
     if (isInitialLoading) {
-      sessionStorage.removeItem('scrollPosition')
+      sessionStorage.removeItem(keyName)
       return
     }
     if (isFetchingMore) return
 
-    const savedScrollPosition = sessionStorage.getItem('scrollPosition')
+    const savedScrollPosition = sessionStorage.getItem(keyName)
     if (savedScrollPosition) {
       window.scrollTo(0, parseInt(savedScrollPosition))
-      sessionStorage.removeItem('scrollPosition')
+      sessionStorage.removeItem(keyName)
     }
-  }, [isInitialLoading, isFetchingMore])
+  }, [isInitialLoading, isFetchingMore, keyName])
 }
 
 export default useSavedScrollPosition

--- a/frontend/app/src/pages/current/posts.tsx
+++ b/frontend/app/src/pages/current/posts.tsx
@@ -1,8 +1,10 @@
 import { Box, CircularProgress, Container, Typography } from '@mui/material'
 import CurrentPostList from '@/components/CurrentPostList'
+import Error from '@/components/Error'
 import Loader from '@/components/Loader'
 import { useFetchPosts } from '@/hooks/useFetchPosts'
 import useInfiniteScroll from '@/hooks/useInfiniteScroll'
+import useSavedScrollPosition from '@/hooks/useSavedScrollPosition'
 import { useRequireSignedIn } from '@/hooks/useRequireSignedIn'
 import { useUserState } from '@/hooks/useGlobalState'
 import { styles } from '@/styles'
@@ -10,6 +12,7 @@ import { styles } from '@/styles'
 const CurrentPosts = () => {
   useRequireSignedIn()
   const [user] = useUserState()
+  const apiPath = user.isSignedIn ? '/current/posts' : '/posts'
 
   const {
     postData,
@@ -18,12 +21,16 @@ const CurrentPosts = () => {
     isFetchingMore,
     loadMorePosts,
     hasMore,
-  } = useFetchPosts('/current/posts')
+  } = useFetchPosts(apiPath)
 
   const { triggerRef } = useInfiniteScroll(loadMorePosts, hasMore)
+  useSavedScrollPosition(
+    isInitialLoading,
+    isFetchingMore,
+    'scrollPositionCurrentPosts'
+  )
 
-  if (!user.isSignedIn) return <div>サインインが必要です。</div>
-  if (error) return <div>エラーが発生しました。</div>
+  if (error) return <Error />
   if (isInitialLoading) return <Loader />
 
   return (

--- a/frontend/app/src/pages/current/posts/[id].tsx
+++ b/frontend/app/src/pages/current/posts/[id].tsx
@@ -1,15 +1,27 @@
+import { Settings } from '@mui/icons-material'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
-import { Avatar, Box, Container, IconButton, Tooltip } from '@mui/material'
+import {
+  Avatar,
+  Box,
+  Container,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { styles } from '@/styles'
 import Error from '@/components/Error'
-import PostDetailItem from '@/components/PostDetailItem'
 import Loader from '@/components/Loader'
 import { useFetchPostDetail } from '@/hooks/useFetchPostDetail'
-import { styles } from '@/styles'
+import { useRequireSignedIn } from '@/hooks/useRequireSignedIn'
+import { useUserState } from '@/hooks/useGlobalState'
 import { Link, useParams } from 'react-router-dom'
+import PostDetailItem from '@/components/PostDetailItem'
 
-const PostDetail = () => {
+const CurrentPostDetail = () => {
+  useRequireSignedIn()
+  const [user] = useUserState()
   const { id } = useParams<{ id: string }>()
-  const apiPath = `/posts/${id?.toString()}`
+  const apiPath = user.isSignedIn ? `/current/posts/${id?.toString()}` : null
   const { post, loading, error } = useFetchPostDetail(apiPath)
 
   if (error) return <Error />
@@ -35,9 +47,9 @@ const PostDetail = () => {
           }}
         >
           <Box sx={{ flexGrow: 1 }}>
-            <Link to="/posts">
+            <Link to="/current/posts">
               <Avatar>
-                <Tooltip title="投稿一覧に戻る">
+                <Tooltip title="投稿の管理に戻る">
                   <IconButton sx={{ backgroundColor: '#F1F5FA' }}>
                     <ChevronLeftIcon sx={{ color: '#99AAB6' }} />
                   </IconButton>
@@ -45,14 +57,21 @@ const PostDetail = () => {
               </Avatar>
             </Link>
           </Box>
-          <Box sx={{ flexGrow: 1 }} />
+          <Box sx={{ flexGrow: 1, textAlign: 'center' }}>
+            <Settings />
+            <Typography
+              component="p"
+              sx={{ display: 'inline-block', fontSize: { xs: 14, sm: 16 } }}
+            >
+              ステータス： {post?.status}
+            </Typography>
+          </Box>
           <Box sx={{ flexGrow: 1 }} />
         </Container>
       </Box>
-      {/* 投稿データの表示 */}
       <PostDetailItem key={`${post?.id}`} post={post} />
     </Box>
   )
 }
 
-export default PostDetail
+export default CurrentPostDetail

--- a/frontend/app/src/pages/index.tsx
+++ b/frontend/app/src/pages/index.tsx
@@ -18,7 +18,11 @@ const Index = () => {
   } = useFetchPosts('/posts')
 
   const { triggerRef } = useInfiniteScroll(loadMorePosts, hasMore)
-  useSavedScrollPosition(isInitialLoading, isFetchingMore)
+  useSavedScrollPosition(
+    isInitialLoading,
+    isFetchingMore,
+    'scrollPositionPosts'
+  )
 
   if (error) return <Error />
   if (isInitialLoading) return <Loader />


### PR DESCRIPTION
## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes #60

## やったこと
<!-- このプルリクで何をしたのか？ -->
- サインインユーザー投稿詳細ページ `current/posts/[id].tsx` を作成
- 投稿詳細ページのデザイン統一
- APIのタイムゾーンを `Asia/Tokyo` に設定

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- サインインユーザーの投稿詳細表示

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- なし

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- サインインユーザーの投稿詳細表示

https://github.com/user-attachments/assets/353f073f-f477-4d70-b058-2f95dcfa451e

