### PR TITLE
feat: サインアップページを実装した

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Bundler and gem install
         run: |
           bundle config set path 'vendor/bundle'
-          bundle install --jobs 4 --retry 3
+          bundle install --without development --jobs 4 --retry 3
 
       - name: Database create and migrate
         run: |
@@ -93,7 +93,7 @@ jobs:
       - name: Bundler and gem install
         run: |
           bundle config set path 'vendor/bundle'
-          bundle install --jobs 4 --retry 3
+          bundle install --without development --jobs 4 --retry 3
 
       - name: Run rubocop
         run: bundle exec rubocop --server

--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -10,3 +10,7 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # Overwrite or add rules to create your own house style
 AllCops:
   TargetRubyVersion: 3.4.1
+
+require:
+  - ./lib/rubocop/rails/schema_loader/schema.rb
+  - ./lib/rubocop/rails/schema_loader.rb

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -71,8 +71,6 @@ group :development, :test do
   # デバッグツール pryコンソールを使えるようにする
   # [https://github.com/deivid-rodriguez/pry-byebug]
   gem 'pry-byebug'
-  # [https://github.com/pry/pry-doc]
-  gem 'pry-doc'
   # [https://github.com/pry/pry-rails]
   gem 'pry-rails'
 
@@ -81,20 +79,6 @@ group :development, :test do
 
   # https://github.com/rspec/rspec-rails
   gem 'rspec-rails'
-
-  # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
-  gem 'rubocop-rails-omakase', require: false
-
-  # [https://matchers.shoulda.io/docs/v5.3.0/]
-  gem 'shoulda-matchers', '~> 5.0'
-end
-
-group :development do
-  # bulk insert[https://github.com/zdennis/activerecord-import]
-  gem 'activerecord-import'
-
-  # N+1問題を検知する [https://github.com/flyerhzm/bullet]
-  gem 'bullet'
 
   # rubocop
   # https://github.com/rubocop/rubocop
@@ -106,9 +90,26 @@ group :development do
   # https://github.com/rubocop/rubocop-rails
   gem 'rubocop-rails', require: false
 
+  # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
+  gem 'rubocop-rails-omakase', require: false
+
   # https://github.com/rubocop/rubocop-rspec
   gem 'rubocop-rspec', require: false
 
+  # [https://matchers.shoulda.io/docs/v5.3.0/]
+  gem 'shoulda-matchers', '~> 5.0'
+
   # RSpec実行高速化[https://github.com/jonleighton/spring-commands-rspec]
   gem 'spring-commands-rspec'
+end
+
+group :development do
+  # bulk insert[https://github.com/zdennis/activerecord-import]
+  gem 'activerecord-import'
+
+  # N+1問題を検知する [https://github.com/flyerhzm/bullet]
+  gem 'bullet'
+
+  # [https://github.com/pry/pry-doc]
+  gem 'pry-doc'
 end

--- a/backend/app/controllers/api/v1/overrides/confirmations_controller.rb
+++ b/backend/app/controllers/api/v1/overrides/confirmations_controller.rb
@@ -1,0 +1,28 @@
+module Api
+  module V1
+    module Overrides
+      class ConfirmationsController < DeviseTokenAuth::ConfirmationsController
+        def create
+          user = resource_class.find_by(email: params[:email])
+
+          return head :ok unless user
+            user.reload
+
+            if recently_resent?(user)
+              return render json: { errors: ['再送は1分後に行えます'] }, status: :too_many_requests
+            end
+
+            user.update!(last_confirmation_sent_at: Time.current)
+          super
+        end
+
+        private
+
+        def recently_resent?(user)
+          user.last_confirmation_sent_at.present? &&
+            user.last_confirmation_sent_at > 1.minute.ago
+        end
+      end
+    end
+  end
+end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,4 +1,13 @@
 class ApplicationController < ActionController::API
-        include DeviseTokenAuth::Concerns::SetUserByToken
-        include DeviseHackFakeSession
+  include DeviseTokenAuth::Concerns::SetUserByToken
+  include DeviseHackFakeSession
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  # サインアップ時にnameの設定を許可
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[name nickname])
+  end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,12 +1,27 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  include DeviseTokenAuth::Concerns::User
+  USERNAME_MAX_LENGTH = 30
+  NICKNAME_MAX_LENGTH = 30
+
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
-  include DeviseTokenAuth::Concerns::User
+
+  validates :name, presence: true, uniqueness: true, format: { with: /\A[a-zA-Z0-9_]+\z/ }, length: { maximum: USERNAME_MAX_LENGTH }
+  validates :nickname, presence: true
+  validate :nickname_length_within_limit
 
   has_many :posts, dependent: :destroy
   has_many :for_order_posts, -> { order(updated_at: :desc, id: :desc) }, dependent: :destroy, inverse_of: :user, class_name: :Post
+
+  private
+
+  def nickname_length_within_limit
+    if nickname.present? && nickname.length > NICKNAME_MAX_LENGTH
+      errors.add(:nickname, "は#{NICKNAME_MAX_LENGTH}文字以内で入力してください")
+    end
+  end
 end

--- a/backend/app/serializers/current_user_serializer.rb
+++ b/backend/app/serializers/current_user_serializer.rb
@@ -1,3 +1,3 @@
 class CurrentUserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email
+  attributes :id, :name, :nickname, :email
 end

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -1,4 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :name
+  attributes :name, :nickname
   has_many :for_order_posts, serializer: PostSerializer
 end

--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -63,4 +63,5 @@ DeviseTokenAuth.setup do |config|
   # devise confirmable module. If you want to use devise confirmable module and
   # send email, set it to true. (This is a setting for compatibility)
   # config.send_confirmation_email = true
+  config.default_confirm_success_url = 'http://localhost:5173/sign_in'
 end

--- a/backend/config/locales/devise.views.ja.yml
+++ b/backend/config/locales/devise.views.ja.yml
@@ -15,6 +15,8 @@ ja:
         last_sign_in_at: 最終ログイン時刻
         last_sign_in_ip: 最終ログインIPアドレス
         locked_at: ロック時刻
+        name: user_name
+        nickname: ユーザー名
         password: パスワード
         password_confirmation: パスワード（確認用）
         remember_created_at: ログイン記憶時刻
@@ -141,3 +143,10 @@ ja:
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+    models:
+      user:
+        attributes:
+          name:
+            blank: "を入力してください"
+            taken: "はすでに使用されています"
+            invalid: "は英数字とアンダースコア(_)のみ使用できます"

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get 'health_check', to: 'health_check#index'
-      mount_devise_token_auth_for 'User', at: 'auth'
+      mount_devise_token_auth_for 'User', at: 'auth', controllers: {
+        confirmations: 'api/v1/overrides/confirmations',
+      }
 
       namespace :current do
         resource :user, only: %i[show]

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -35,16 +35,17 @@ ActiveRecord::Schema[8.0].define(version: 0) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
-    t.string "name"
-    t.string "nickname"
+    t.string "name", null: false
+    t.string "nickname", null: false
     t.string "image"
-    t.string "email"
+    t.string "email", null: false
     t.text "tokens"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["name", "uid"], name: "index_users_on_name_and_uid"
+    t.index ["name"], name: "index_users_on_name", unique: true
+    t.index ["nickname"], name: "index_users_on_nickname"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -35,6 +35,7 @@ ActiveRecord::Schema[8.0].define(version: 0) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.datetime "last_confirmation_sent_at"
     t.string "name", null: false
     t.string "nickname", null: false
     t.string "image"

--- a/backend/db/schemas/users.schema.rb
+++ b/backend/db/schemas/users.schema.rb
@@ -4,24 +4,16 @@ create_table :users,
               collation: 'utf8mb4_bin',
               options: 'ENGINE=InnoDB ROW_FORMAT=DYNAMIC' do |t|
   ## Required
-  t.string :provider,
-            null: false,
-            default: 'email'
-  t.string :uid,
-            null: false,
-            default: ""
+  t.string :provider, null: false, default: 'email'
+  t.string :uid, null: false, default: ""
 
   ## Database authenticatable
-  t.string :encrypted_password,
-            null: false,
-            default: ""
+  t.string :encrypted_password, null: false, default: ""
 
   ## Recoverable
   t.string :reset_password_token
   t.datetime :reset_password_sent_at
-  t.boolean :allow_password_change,
-             null: false,
-             default: false
+  t.boolean :allow_password_change, null: false, default: false
 
   ## Rememberable
   t.datetime :remember_created_at
@@ -38,10 +30,10 @@ create_table :users,
   # t.datetime :locked_at
 
   ## User Info
-  t.string :name
-  t.string :nickname
+  t.string :name, null: false
+  t.string :nickname, null: false
   t.string :image
-  t.string :email
+  t.string :email, null: false
 
   ## Tokens
   t.text :tokens
@@ -51,7 +43,7 @@ end
 
 add_index :users, :email, unique: true
 add_index :users, %i[uid provider], unique: true
+add_index :users, :name, unique: true
+add_index :users, :nickname
 add_index :users, :reset_password_token, unique: true
 add_index :users, :confirmation_token, unique: true
-# add_index :users, :unlock_token, unique: true
-add_index :users, %i[name uid]

--- a/backend/db/schemas/users.schema.rb
+++ b/backend/db/schemas/users.schema.rb
@@ -23,6 +23,7 @@ create_table :users,
   t.datetime :confirmed_at
   t.datetime :confirmation_sent_at
   t.string :unconfirmed_email # Only if using reconfirmable
+  t.datetime :last_confirmation_sent_at
 
   ## Lockable
   # t.integer :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -6,13 +6,15 @@ Faker::Config.random = Random.new(FAKER_RANDOM_NUM)
 
 users = []
 USERS_COUNT.times do |i|
-  name = "ユーザー#{i + 1}"
-  uid = "user#{i + 1}"
+  name = "user#{i + 1}_#{Faker::Internet.username(specifier: 5..10, separators: ['_'])}"
+  nickname = "ユーザー#{i + 1}"
   email = "user#{i + 1}@example.com"
+  uid = "user#{i + 1}@example.com"
+  provider = 'email'
   password = 'p@ssw0rd'
   confirmed_at = Time.current
 
-  users << User.new(name:, uid:, email:, password:, confirmed_at:)
+  users << User.new(name:, nickname:, email:, uid:, provider:, password:, confirmed_at:)
 end
 
 User.import users

--- a/backend/lib/rubocop/rails/schema_loader.rb
+++ b/backend/lib/rubocop/rails/schema_loader.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# https://github.com/rubocop/rubocop-rails/blob/2a217d0c70e4c1d24efa6b638e93fa693a938276/lib/rubocop/rails/schema_loader.rb
+
+module RuboCop
+  module Rails
+    # It loads db/schema.rb and return Schema object.
+    # Cops refers database schema information with this module.
+    module SchemaLoader
+      extend self
+
+      # It parses `db/schema.rb` and return it.
+      # It returns `nil` if it can't find `db/schema.rb`.
+      # So a cop that uses the loader should handle `nil` properly.
+      #
+      # @return [Schema, nil]
+      def load(target_ruby_version)
+        return @schema if defined?(@schema)
+
+        @schema = load!(target_ruby_version)
+      end
+
+      def reset!
+        return unless instance_variable_defined?(:@schema)
+
+        remove_instance_variable(:@schema)
+      end
+
+      private
+
+      def load!(target_ruby_version)
+        path = db_schema_path
+        return unless path
+
+        ast = parse(path, target_ruby_version)
+        Schema.new(ast)
+      end
+
+      def db_schema_path
+        path = Pathname.pwd
+        until path.root?
+          schema_path = path.join('db/schema.rb')
+          return schema_path if schema_path.exist?
+
+          path = path.join('../').cleanpath
+        end
+
+        nil
+      end
+
+      def parse(path, target_ruby_version)
+        klass_name = :"Ruby#{target_ruby_version.to_s.sub('.', '')}"
+        klass = ::Parser.const_get(klass_name)
+        parser = klass.new(RuboCop::AST::Builder.new)
+
+        buffer = Parser::Source::Buffer.new(path, 1)
+        buffer.source = path.read
+
+        parser.parse(buffer)
+      end
+    end
+  end
+end

--- a/backend/lib/rubocop/rails/schema_loader.rb
+++ b/backend/lib/rubocop/rails/schema_loader.rb
@@ -2,7 +2,7 @@
 
 # https://github.com/rubocop/rubocop-rails/blob/2a217d0c70e4c1d24efa6b638e93fa693a938276/lib/rubocop/rails/schema_loader.rb
 
-module RuboCop
+module Rubocop
   module Rails
     # It loads db/schema.rb and return Schema object.
     # Cops refers database schema information with this module.

--- a/backend/lib/rubocop/rails/schema_loader/schema.rb
+++ b/backend/lib/rubocop/rails/schema_loader/schema.rb
@@ -2,7 +2,7 @@
 
 # https://github.com/rubocop/rubocop-rails/blob/2a217d0c70e4c1d24efa6b638e93fa693a938276/lib/rubocop/rails/schema_loader.rb
 
-module RuboCop
+module Rubocop
   module Rails
     module SchemaLoader
       # Represent db/schema.rb

--- a/backend/lib/rubocop/rails/schema_loader/schema.rb
+++ b/backend/lib/rubocop/rails/schema_loader/schema.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+# https://github.com/rubocop/rubocop-rails/blob/2a217d0c70e4c1d24efa6b638e93fa693a938276/lib/rubocop/rails/schema_loader.rb
+
+module RuboCop
+  module Rails
+    module SchemaLoader
+      # Represent db/schema.rb
+      class Schema
+        attr_reader :tables, :add_indices
+
+        def initialize(ast)
+          @tables = []
+          @add_indices = []
+
+          build!(ast)
+        end
+
+        def table_by(name:)
+          tables.detect do |table|
+            table.name == name
+          end
+        end
+
+        def add_indices_by(table_name:)
+          add_indices.select do |add_index|
+            add_index.table_name == table_name
+          end
+        end
+
+        private
+
+        def build!(ast)
+          raise "Unexpected type: #{ast.type}" unless ast.block_type?
+          return unless ast.body
+
+          each_table(ast) do |table_def|
+            next unless table_def.method?(:create_table)
+
+            @tables << Table.new(table_def)
+          end
+
+          # Compatibility for Rails 4.2.
+          each_add_index(ast) do |add_index_def|
+            @add_indices << AddIndex.new(add_index_def)
+          end
+        end
+
+        def each_table(ast)
+          case ast.body.type
+          when :begin
+            ast.body.children.each do |node|
+              next unless node.block_type? && node.method?(:create_table)
+
+              yield(node)
+            end
+          else
+            yield ast.body
+          end
+        end
+
+        def each_add_index(ast)
+          ast.body.children.each do |node|
+            next unless node.respond_to?(:send_type?)
+            next if !node&.send_type? || !node.method?(:add_index)
+
+            yield(node)
+          end
+        end
+      end
+
+      # Represent a table
+      class Table
+        attr_reader :name, :columns, :indices
+
+        def initialize(node)
+          @name = node.send_node.first_argument.value
+          @columns = build_columns(node)
+          @indices = build_indices(node)
+        end
+
+        def with_column?(name:)
+          @columns.any? {|c| c.name == name }
+        end
+
+        private
+
+        def build_columns(node)
+          each_content(node).filter_map do |child|
+            next unless child&.send_type?
+            next if child.method?(:index)
+
+            Column.new(child)
+          end
+        end
+
+        def build_indices(node)
+          each_content(node).filter_map do |child|
+            next unless child&.send_type?
+            next unless child.method?(:index)
+
+            Index.new(child)
+          end
+        end
+
+        def each_content(node, &block)
+          return enum_for(__method__, node) unless block
+
+          case node.body&.type
+          when :begin
+            node.body.children.each(&block)
+          else
+            yield(node.body)
+          end
+        end
+      end
+
+      # Represent a column
+      class Column
+        attr_reader :name, :type, :not_null
+
+        def initialize(node)
+          @name = node.first_argument.str_content
+          @type = node.method_name
+          @not_null = nil
+
+          analyze_keywords!(node)
+        end
+
+        private
+
+        def analyze_keywords!(node)
+          pairs = node.last_argument
+          return unless pairs.hash_type?
+
+          pairs.each_pair do |k, v|
+            @not_null = !v.true_type? if k.value == :null
+          end
+        end
+      end
+
+      # Represent an index
+      class Index
+        attr_reader :name, :columns, :expression, :unique
+
+        def initialize(node)
+          @columns, @expression = build_columns_or_expr(node.first_argument)
+          @unique = nil
+
+          analyze_keywords!(node)
+        end
+
+        private
+
+        def build_columns_or_expr(columns)
+          if columns.array_type?
+            [columns.values.map(&:value), nil]
+          else
+            [[], columns.value]
+          end
+        end
+
+        def analyze_keywords!(node)
+          pairs = node.last_argument
+          return unless pairs.hash_type?
+
+          pairs.each_pair do |k, v|
+            case k.value
+            when :name
+              @name = v.value
+            when :unique
+              @unique = true
+            end
+          end
+        end
+      end
+
+      # Represent an `add_index`
+      class AddIndex < Index
+        attr_reader :table_name
+
+        def initialize(node)
+          super
+
+          @table_name = node.first_argument.value
+          @columns, @expression = build_columns_or_expr(node.arguments[1])
+          @unique = nil
+
+          analyze_keywords!(node)
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :user do
-    name { Faker::Name.name }
-    email { Faker::Internet.email }
+    sequence(:name) {|n| "user_#{n}_#{Faker::Internet.username(specifier: 5..10, separators: ['_'])}" }
+    nickname { Faker::Name.name }
+    email { Faker::Internet.unique.email }
     password { Faker::Internet.password(min_length: 8) }
     confirmed_at { Time.current }
   end

--- a/backend/spec/factories/users.rb
+++ b/backend/spec/factories/users.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     email { Faker::Internet.unique.email }
     password { Faker::Internet.password(min_length: 8) }
     confirmed_at { Time.current }
+
+    trait :unconfirmed do
+      confirmed_at { nil }
+      after(:build) {|u| u.skip_confirmation_notification! }
+    end
   end
 end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe User, type: :model do
 
     it { should validate_presence_of(:email) }
     it { should validate_uniqueness_of(:email).case_insensitive.scoped_to(:provider) }
+    it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name) }
+    it { should validate_length_of(:name).is_at_most(User::USERNAME_MAX_LENGTH) }
+    it { should validate_presence_of(:nickname) }
+    it { should allow_value('卍' * User::NICKNAME_MAX_LENGTH).for(:nickname) }
+    it { should_not allow_value('卍' * (User::NICKNAME_MAX_LENGTH + 1)).for(:nickname) }
     it { should validate_presence_of(:password) }
   end
 

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -18,15 +18,20 @@ RSpec.describe User, type: :model do
   end
 
   describe 'メール認証のテスト' do
-    let!(:user) { create(:user, confirmed_at: nil) }
+    context '未認証ユーザーのとき' do
+      let!(:user) { build_stubbed(:user, confirmed_at: nil) }
 
-    it '未認証のユーザーは confirmed_at が nil である' do
-      expect(user.confirmed_at).to be_nil
+      it 'confirmed_at が nil である' do
+        expect(user.confirmed_at).to be_nil
+      end
     end
 
-    it 'メール認証後は confirmed_at がセットされる' do
-      user.confirm
-      expect(user.confirmed_at).not_to be_nil
+    context '認証済みユーザーのとき' do
+      let!(:user) { create(:user, :unconfirmed) }
+      it 'メール認証後は confirmed_at がセットされる' do
+        user.confirm
+        expect(user.confirmed_at).not_to be_nil
+      end
     end
   end
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -68,6 +68,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::ControllerHelpers, type: :controller
+
   # FactoryBotクラス名省略
   config.include FactoryBot::Syntax::Methods
 end

--- a/backend/spec/requests/api/v1/current/posts_spec.rb
+++ b/backend/spec/requests/api/v1/current/posts_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Api::V1::Current::Posts', type: :request do
           aggregate_failures do
             expect(res.keys).to eq ['posts', 'meta']
             expect(res['posts'][0].keys).to eq ['id', 'content', 'status', 'created_at', 'created_at_from_today', 'updated_at', 'updated_at_from_today', 'user']
-            expect(res['posts'][0]['user'].keys).to eq ['name']
+            expect(res['posts'][0]['user'].keys).to eq ['name', 'nickname']
             expect(res['meta'].keys).to eq ['next_keyset']
             expect(res['meta']['next_keyset'].keys).to eq ['updated_at', 'id']
           end
@@ -73,7 +73,7 @@ RSpec.describe 'Api::V1::Current::Posts', type: :request do
           aggregate_failures do
             expect(res.keys).to eq ['posts', 'meta']
             expect(res['posts'][0].keys).to eq ['id', 'content', 'status', 'created_at', 'created_at_from_today', 'updated_at', 'updated_at_from_today', 'user']
-            expect(res['posts'][0]['user'].keys).to eq ['name']
+            expect(res['posts'][0]['user'].keys).to eq ['name', 'nickname']
             expect(res['meta'].keys).to eq ['next_keyset']
             expect(res['meta']['next_keyset'].keys).to eq ['updated_at', 'id']
           end
@@ -159,7 +159,7 @@ RSpec.describe 'Api::V1::Current::Posts', type: :request do
           subject
           res = response.parsed_body
           expect(res.keys).to eq ['id', 'content', 'status', 'created_at', 'created_at_from_today', 'updated_at', 'updated_at_from_today', 'user']
-          expect(res['user'].keys).to eq ['name']
+          expect(res['user'].keys).to eq ['name', 'nickname']
           expect(response).to have_http_status(:ok)
         end
       end
@@ -191,7 +191,7 @@ RSpec.describe 'Api::V1::Current::Posts', type: :request do
           expect(current_user.posts.last).to be_unsaved
           res = response.parsed_body
           expect(res.keys).to eq ['id', 'content', 'status', 'created_at', 'created_at_from_today', 'updated_at', 'updated_at_from_today', 'user']
-          expect(res['user'].keys).to eq ['name']
+          expect(res['user'].keys).to eq ['name', 'nickname']
           expect(response).to have_http_status(:ok)
         end
       end
@@ -205,7 +205,7 @@ RSpec.describe 'Api::V1::Current::Posts', type: :request do
           expect { subject }.not_to change { current_user.posts.count }
           res = response.parsed_body
           expect(res.keys).to eq ['id', 'content', 'status', 'created_at', 'created_at_from_today', 'updated_at', 'updated_at_from_today', 'user']
-          expect(res['user'].keys).to eq ['name']
+          expect(res['user'].keys).to eq ['name', 'nickname']
           expect(response).to have_http_status(:ok)
         end
       end
@@ -230,7 +230,7 @@ RSpec.describe 'Api::V1::Current::Posts', type: :request do
             change { current_user_post.reload.status }.from('draft').to('published')
           res = response.parsed_body
           expect(res.keys).to eq ['id', 'content', 'status', 'created_at', 'created_at_from_today', 'updated_at', 'updated_at_from_today', 'user']
-          expect(res['user'].keys).to eq ['name']
+          expect(res['user'].keys).to eq ['name', 'nickname']
           expect(response).to have_http_status(:ok)
         end
       end

--- a/backend/spec/requests/api/v1/current/users_spec.rb
+++ b/backend/spec/requests/api/v1/current/users_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Api::V1::Current::Users', type: :request do
         subject
         res = response.parsed_body
         aggregate_failures do
-          expect(res.keys).to eq ['id', 'name', 'email']
+          expect(res.keys).to eq ['id', 'name', 'nickname', 'email']
           expect(response).to have_http_status(:success)
         end
       end

--- a/backend/spec/requests/api/v1/overrides/confirmations_spec.rb
+++ b/backend/spec/requests/api/v1/overrides/confirmations_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe 'Overrides::Confirmations', type: :request do
+  describe 'POST api/v1/auth/confirmation' do
+    let!(:user) { create(:user, confirmed_at: nil) }
+    let!(:email) { user.email }
+    let!(:headers) { { 'Content-Type': 'application/json' } }
+    let!(:params) { { email: email, redirect_url: 'http://localhost:3000/api/v1/sign_in' } }
+
+    subject { post '/api/v1/auth/confirmation', params: params.to_json, headers: headers }
+
+    context '認証メールの再送ができるとき' do
+      it 'レスポンス ok が返る' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '前回の再送リクエストから1分経過していないとき' do
+      before do
+        user.update!(last_confirmation_sent_at: 30.seconds.ago)
+      end
+
+      it 'too_many_requests エラーを返す' do
+        subject
+        expect(response).to have_http_status(:too_many_requests)
+        expect(response.parsed_body['errors']).to include('再送は1分後に行えます')
+      end
+    end
+
+    context '存在しないメールアドレスを指定したとき' do
+      let!(:email) { 'nonexistent@example.com' }
+
+      it 'does not return error' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/posts_spec.rb
+++ b/backend/spec/requests/api/v1/posts_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Api::V1::Posts', type: :request do
         aggregate_failures do
           expect(res.keys).to eq ['posts', 'meta']
           expect(res['posts'][0].keys).to eq ['id', 'content', 'status', 'created_at', 'created_at_from_today', 'updated_at', 'updated_at_from_today', 'user']
-          expect(res['posts'][0]['user'].keys).to eq ['name']
+          expect(res['posts'][0]['user'].keys).to eq ['name', 'nickname']
           expect(res['meta'].keys).to eq ['next_keyset']
           expect(res['meta']['next_keyset'].keys).to eq ['updated_at', 'id']
         end
@@ -64,7 +64,7 @@ RSpec.describe 'Api::V1::Posts', type: :request do
         aggregate_failures do
           expect(res.keys).to eq ['posts', 'meta']
           expect(res['posts'][0].keys).to eq ['id', 'content', 'status', 'created_at', 'created_at_from_today', 'updated_at', 'updated_at_from_today', 'user']
-          expect(res['posts'][0]['user'].keys).to eq ['name']
+          expect(res['posts'][0]['user'].keys).to eq ['name', 'nickname']
           expect(res['meta'].keys).to eq ['next_keyset']
           expect(res['meta']['next_keyset'].keys).to eq ['updated_at', 'id']
         end
@@ -144,7 +144,7 @@ RSpec.describe 'Api::V1::Posts', type: :request do
           aggregate_failures do
             expect(response).to have_http_status(:success)
             expect(res.keys).to eq ['id', 'content', 'status', 'created_at', 'created_at_from_today', 'updated_at', 'updated_at_from_today', 'user']
-            expect(res['user'].keys).to eq ['name']
+            expect(res['user'].keys).to eq ['name', 'nickname']
           end
         end
       end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -14,6 +14,7 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.before(:suite) { Faker::UniqueGenerator.clear }
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/frontend/app/.env.development
+++ b/frontend/app/.env.development
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=http://localhost:3000/api/v1
+VITE_FRONTEND_BASE_URL=http://localhost:5173

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -12,19 +12,20 @@ import PostDetail from './pages/posts/[id]'
 import SignIn from './pages/sign_in'
 import SignOut from './pages/sign_out'
 import SignUp from './pages/sign_up'
+import SignUpComplete from './pages/sign_up/complete'
 
 // ヘッダー
 import Header from './components/Header'
 
 // 通知バー
-import Snackbar from './components/Snackbar'
+import SnackbarItem from './components/SnackbarItem'
 
 function App() {
   return (
     <Router>
       <CurrentUserFetch />
       <Header />
-      <Snackbar />
+      <SnackbarItem />
 
       <Routes>
         {/* ホームページ */}
@@ -47,6 +48,8 @@ function App() {
         <Route path="/sign_out" element={<SignOut />} />
         {/* サインアップページ */}
         <Route path="/sign_up" element={<SignUp />} />
+        {/* サインアップ完了ページ */}
+        <Route path="/sign_up/complete" element={<SignUpComplete />} />
       </Routes>
     </Router>
   )

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -11,6 +11,7 @@ import Index from './pages/index'
 import PostDetail from './pages/posts/[id]'
 import SignIn from './pages/sign_in'
 import SignOut from './pages/sign_out'
+import SignUp from './pages/sign_up'
 
 // ヘッダー
 import Header from './components/Header'
@@ -41,9 +42,11 @@ function App() {
         {/* 投稿詳細ページ */}
         <Route path="/posts/:id" element={<PostDetail />} />
         {/* サインインページ */}
-        <Route path="/sign-in" element={<SignIn />} />
+        <Route path="/sign_in" element={<SignIn />} />
         {/* サインアウトページ */}
-        <Route path="/sign-out" element={<SignOut />} />
+        <Route path="/sign_out" element={<SignOut />} />
+        {/* サインアップページ */}
+        <Route path="/sign_up" element={<SignUp />} />
       </Routes>
     </Router>
   )

--- a/frontend/app/src/components/Header.tsx
+++ b/frontend/app/src/components/Header.tsx
@@ -95,7 +95,7 @@ const Header = () => {
                 <Box>
                   <Button
                     component={Link}
-                    to="/sign-in"
+                    to="/sign_in"
                     color="primary"
                     variant="contained"
                     sx={{
@@ -110,7 +110,7 @@ const Header = () => {
                   </Button>
                   <Button
                     component={Link}
-                    to="/sign-up"
+                    to="/sign_up"
                     color="primary"
                     variant="outlined"
                     sx={{
@@ -173,7 +173,7 @@ const Header = () => {
                       </ListItemIcon>
                       投稿の管理
                     </MenuItem>
-                    <MenuItem component={Link} to="/sign-out">
+                    <MenuItem component={Link} to="/sign_out">
                       <ListItemIcon>
                         <Logout fontSize="small" />
                       </ListItemIcon>

--- a/frontend/app/src/components/SignUpCompleteUI.tsx
+++ b/frontend/app/src/components/SignUpCompleteUI.tsx
@@ -1,0 +1,48 @@
+import { Box, Button, Card, CardContent, Typography } from '@mui/material'
+
+const SignUpCompleteUI = ({
+  email,
+  handleResend,
+  isSubmitting,
+  canResend,
+}: {
+  email: string
+  handleResend: () => void
+  isSubmitting: boolean
+  canResend: boolean
+}) => {
+  return (
+    <Box sx={{ mb: 4, pt: 4 }}>
+      <Typography
+        component="h2"
+        sx={{ fontSize: 24, color: 'black', fontWeight: 'bold' }}
+      >
+        仮登録が完了しました
+      </Typography>
+      <Card sx={{ p: 3, mt: 8, backgroundColor: 'white' }}>
+        <CardContent sx={{ lineHeight: 2 }}>
+          <p>
+            {email}に、認証用メールを送信しました。
+            <br />
+            メール内のURLから、認証を完了してください。
+            <br />
+            迷惑メールフォルダに届く場合があります。ご確認ください。
+          </p>
+        </CardContent>
+      </Card>
+      <Box sx={{ mt: 4, textAlign: 'center', width: '100%' }}>
+        <Button
+          onClick={handleResend}
+          variant="outlined"
+          sx={{ mt: 2 }}
+          disabled={isSubmitting || !canResend}
+          fullWidth
+        >
+          {isSubmitting ? '再送信中...' : '認証メールを再送信'}
+        </Button>
+      </Box>
+    </Box>
+  )
+}
+
+export default SignUpCompleteUI

--- a/frontend/app/src/components/SignUpForm.tsx
+++ b/frontend/app/src/components/SignUpForm.tsx
@@ -1,0 +1,171 @@
+import { Button, Stack, TextField } from '@mui/material'
+import axios, { AxiosError } from 'axios'
+import { useState } from 'react'
+import { useForm, Controller, SubmitHandler } from 'react-hook-form'
+import { useSnackbarState } from '@/hooks/useGlobalState'
+import { validationRules } from '@/validations/signUpValidation'
+
+type SignUpFormData = {
+  email: string
+  password: string
+  name: string
+  nickname: string
+}
+
+type SignUpErrorResponse = {
+  errors?: {
+    full_messages: string[]
+  }
+}
+
+const SignUpForm = () => {
+  const [, setSnackbarState] = useSnackbarState()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const {
+    handleSubmit,
+    control,
+    formState: { isValid },
+  } = useForm<SignUpFormData>({
+    mode: 'onChange',
+    defaultValues: {
+      email: '',
+      password: '',
+      name: '',
+      nickname: '',
+    },
+  })
+
+  const handleError = (error: AxiosError<SignUpErrorResponse>) => {
+    const { response } = error
+    const messages = response?.data?.errors?.full_messages || []
+    if (messages.length > 0) {
+      setSnackbarState({
+        message: messages[0],
+        severity: 'error',
+        pathname: '/sign_up',
+      })
+    }
+  }
+
+  const onSubmit: SubmitHandler<SignUpFormData> = async (data) => {
+    setIsSubmitting(true)
+
+    try {
+      const response = await axios.post(
+        `${import.meta.env.VITE_API_BASE_URL}/auth`,
+        {
+          ...data,
+          confirm_success_url: `${import.meta.env.VITE_FRONTEND_BASE_URL}/sign_in`,
+        },
+        { headers: { 'Content-Type': 'application/json' } }
+      )
+
+      localStorage.setItem(
+        'access-token',
+        response.headers['access-token'] || ''
+      )
+      localStorage.setItem('client', response.headers['client'] || '')
+      localStorage.setItem('uid', response.headers['uid'] || '')
+
+      setSnackbarState({
+        message: '認証メールをご確認ください',
+        severity: 'success',
+        pathname: '/posts',
+      })
+      window.location.href = '/posts'
+    } catch (error) {
+      handleError(error as AxiosError<SignUpErrorResponse>)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Stack
+      component="form"
+      noValidate
+      onSubmit={handleSubmit(onSubmit)}
+      spacing={4}
+    >
+      <Controller
+        name="email"
+        control={control}
+        rules={validationRules.email}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            id="email"
+            type="email"
+            label="メールアドレス"
+            error={fieldState.invalid}
+            helperText={fieldState.error?.message}
+            sx={{ backgroundColor: 'white' }}
+          />
+        )}
+      />
+      <Controller
+        name="password"
+        control={control}
+        rules={validationRules.password}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            id="password"
+            type="password"
+            label="パスワード"
+            error={fieldState.invalid}
+            helperText={fieldState.error?.message}
+            sx={{ backgroundColor: 'white' }}
+          />
+        )}
+      />
+      <Controller
+        name="name"
+        control={control}
+        rules={validationRules.name}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            id="username"
+            type="text"
+            label="user_name"
+            error={fieldState.invalid}
+            helperText={fieldState.error?.message}
+            sx={{ backgroundColor: 'white' }}
+            onInput={(e) => {
+              const input = e.target as HTMLInputElement
+              field.onChange(input.value.replace(/[^\w]/g, ''))
+            }}
+          />
+        )}
+      />
+      <Controller
+        name="nickname"
+        control={control}
+        rules={validationRules.nickname}
+        render={({ field, fieldState }) => (
+          <TextField
+            {...field}
+            id="nickname"
+            type="text"
+            label="ユーザー名"
+            error={fieldState.invalid}
+            helperText={fieldState.error?.message}
+            sx={{ backgroundColor: 'white' }}
+          />
+        )}
+      />
+      <Button
+        type="submit"
+        variant="contained"
+        disabled={!isValid || isSubmitting}
+        sx={{ fontWeight: 'bold', color: 'white' }}
+      >
+        {isSubmitting ? '送信中...' : '送信する'}
+      </Button>
+    </Stack>
+  )
+}
+
+export default SignUpForm

--- a/frontend/app/src/components/SignUpForm.tsx
+++ b/frontend/app/src/components/SignUpForm.tsx
@@ -67,13 +67,14 @@ const SignUpForm = () => {
       )
       localStorage.setItem('client', response.headers['client'] || '')
       localStorage.setItem('uid', response.headers['uid'] || '')
+      localStorage.setItem('signupEmail', data.email || '')
 
       setSnackbarState({
         message: '認証メールをご確認ください',
         severity: 'success',
-        pathname: '/posts',
+        pathname: '/sign_up/complete',
       })
-      window.location.href = '/posts'
+      window.location.href = '/sign_up/complete'
     } catch (error) {
       handleError(error as AxiosError<SignUpErrorResponse>)
     } finally {

--- a/frontend/app/src/components/SnackbarItem.tsx
+++ b/frontend/app/src/components/SnackbarItem.tsx
@@ -2,7 +2,7 @@ import { Snackbar, Alert } from '@mui/material'
 import { useEffect, useState } from 'react'
 import { useSnackbarState } from '@/hooks/useGlobalState'
 
-const SuccessSnackbar = () => {
+const SnackbarItem = () => {
   const [snackbar, setSnackbar] = useSnackbarState()
   const [open, setOpen] = useState(false)
 
@@ -30,7 +30,7 @@ const SuccessSnackbar = () => {
   return (
     <>
       {snackbar.severity != null && (
-        <Snackbar open={open} autoHideDuration={2000} onClose={handleClose}>
+        <Snackbar open={open} autoHideDuration={5000} onClose={handleClose}>
           <Alert
             onClose={handleClose}
             severity={snackbar.severity}
@@ -44,4 +44,4 @@ const SuccessSnackbar = () => {
   )
 }
 
-export default SuccessSnackbar
+export default SnackbarItem

--- a/frontend/app/src/hooks/useRequireSignedIn.ts
+++ b/frontend/app/src/hooks/useRequireSignedIn.ts
@@ -12,9 +12,9 @@ export function useRequireSignedIn() {
       setSnackbar({
         message: 'サインインしてください',
         severity: 'error',
-        pathname: '/sign-in',
+        pathname: '/sign_in',
       })
-      navigate('/sign-in')
+      navigate('/sign_in')
     }
   }, [user, navigate, setSnackbar])
 }

--- a/frontend/app/src/hooks/useResendEmail.ts
+++ b/frontend/app/src/hooks/useResendEmail.ts
@@ -1,0 +1,71 @@
+import axios from 'axios'
+import { useEffect, useState } from 'react'
+import { useSnackbarState } from '@/hooks/useGlobalState'
+
+const useResendEmail = (email: string) => {
+  const [, setSnackbarState] = useSnackbarState()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [canResend, setCanResend] = useState(true)
+  const [resendTimeout, setResendTimeout] = useState<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+
+  useEffect(() => {
+    const lastSent = localStorage.getItem('lastResendTimestamp')
+    if (lastSent) {
+      const timeSinceLastSent = Date.now() - Number(lastSent)
+      const waitTime = 60 * 1000
+
+      if (timeSinceLastSent < waitTime) {
+        setCanResend(false)
+        const remainingTime = waitTime - timeSinceLastSent
+
+        const timerId = setTimeout(() => {
+          setCanResend(true)
+          localStorage.removeItem('lastResendTimestamp')
+        }, remainingTime)
+
+        setResendTimeout(timerId)
+      }
+    }
+
+    return () => {
+      if (resendTimeout) {
+        clearTimeout(resendTimeout)
+      }
+    }
+  }, [resendTimeout])
+
+  const handleResend = async () => {
+    setIsSubmitting(true)
+    try {
+      await axios.post(
+        `${import.meta.env.VITE_API_BASE_URL}/auth/confirmation`,
+        {
+          email,
+          redirect_url: `${import.meta.env.VITE_FRONTEND_BASE_URL}/sign_in`,
+        }
+      )
+      setSnackbarState({
+        message: '認証メールを再送しました',
+        severity: 'success',
+        pathname: '/sign_up/complete',
+      })
+      localStorage.setItem('lastResendTimestamp', String(Date.now()))
+      setCanResend(false)
+    } catch (error) {
+      console.error(error)
+      setSnackbarState({
+        message: '認証メールの再送に失敗しました',
+        severity: 'error',
+        pathname: '/sign_up/complete',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return { isSubmitting, canResend, handleResend }
+}
+
+export default useResendEmail

--- a/frontend/app/src/hooks/useSignIn.ts
+++ b/frontend/app/src/hooks/useSignIn.ts
@@ -34,11 +34,11 @@ export const useSignIn = () => {
       })
       navigate('/posts')
     } catch (error) {
-      console.error('Sign-in error:', error)
+      console.error('Sign_in error:', error)
       setSnackbar({
         message: '登録ユーザーが見つかりません',
         severity: 'error',
-        pathname: '/sign-in',
+        pathname: '/sign_in',
       })
     } finally {
       setIsLoading(false)

--- a/frontend/app/src/main.tsx
+++ b/frontend/app/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './styles/index'
 import './styles/destyle.css'
+import './styles/index'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/app/src/pages/current/posts/[id].tsx
+++ b/frontend/app/src/pages/current/posts/[id].tsx
@@ -28,7 +28,7 @@ const CurrentPostDetail = () => {
   if (loading) return <Loader />
 
   return (
-    <Box sx={(styles.pageMinHeight, { backgroundColor: '#EDF2F7', pb: 6 })}>
+    <Box sx={{ ...styles.pageMinHeight, backgroundColor: '#EDF2F7', pb: 6 }}>
       <Box
         sx={{
           display: 'block',

--- a/frontend/app/src/pages/index.tsx
+++ b/frontend/app/src/pages/index.tsx
@@ -28,7 +28,7 @@ const Index = () => {
   if (isInitialLoading) return <Loader />
 
   return (
-    <Box sx={(styles.pageMinHeight, { backgroundColor: '#E6F2FF' })}>
+    <Box sx={{ ...styles.pageMinHeight, backgroundColor: '#E6F2FF' }}>
       <Container maxWidth="md" sx={{ pt: 6 }}>
         <Typography
           component="h1"

--- a/frontend/app/src/pages/posts/[id].tsx
+++ b/frontend/app/src/pages/posts/[id].tsx
@@ -16,7 +16,7 @@ const PostDetail = () => {
   if (loading) return <Loader />
 
   return (
-    <Box sx={(styles.pageMinHeight, { backgroundColor: '#EDF2F7', pb: 6 })}>
+    <Box sx={{ ...styles.pageMinHeight, backgroundColor: '#EDF2F7', pb: 6 }}>
       <Box
         sx={{
           display: 'block',

--- a/frontend/app/src/pages/sign_up.tsx
+++ b/frontend/app/src/pages/sign_up.tsx
@@ -1,0 +1,23 @@
+import { Box, Container, Typography } from '@mui/material'
+import SignUpForm from '@/components/SignUpForm'
+import { styles } from '@/styles'
+
+const SignUp = () => {
+  return (
+    <Box sx={{ ...styles.pageMinHeight, backgroundColor: '#EDF2F7' }}>
+      <Container maxWidth="sm">
+        <Box sx={{ mb: 4, pt: 4 }}>
+          <Typography
+            component="h2"
+            sx={{ fontSize: 32, color: 'black', fontWeight: 'bold' }}
+          >
+            Sign Up
+          </Typography>
+        </Box>
+        <SignUpForm />
+      </Container>
+    </Box>
+  )
+}
+
+export default SignUp

--- a/frontend/app/src/pages/sign_up/complete.tsx
+++ b/frontend/app/src/pages/sign_up/complete.tsx
@@ -1,0 +1,30 @@
+import { Box, Container } from '@mui/material'
+import { styles } from '@/styles'
+import Error from '@/components/Error'
+import useResendEmail from '@/hooks/useResendEmail'
+import SignUpCompleteUI from '@/components/SignUpCompleteUI'
+
+const SignUpComplete = () => {
+  const email = localStorage.getItem('signupEmail')
+
+  const { handleResend, isSubmitting, canResend } = useResendEmail(email || '')
+
+  if (!email) {
+    return <Error />
+  }
+
+  return (
+    <Box sx={{ ...styles.pageMinHeight, backgroundColor: '#EDF2F7' }}>
+      <Container maxWidth="sm">
+        <SignUpCompleteUI
+          email={email}
+          handleResend={handleResend}
+          isSubmitting={isSubmitting}
+          canResend={canResend}
+        />
+      </Container>
+    </Box>
+  )
+}
+
+export default SignUpComplete

--- a/frontend/app/src/validations/signUpValidation.ts
+++ b/frontend/app/src/validations/signUpValidation.ts
@@ -1,0 +1,39 @@
+export const validationRules = {
+  email: {
+    required: 'メールアドレスを入力してください。',
+    pattern: {
+      value:
+        /^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$/,
+      message: '正しい形式のメールアドレスを入力してください。',
+    },
+  },
+  password: {
+    required: 'パスワードを入力してください。',
+    minLength: {
+      value: 6,
+      message: '6文字以上入力してください。',
+    },
+    maxLength: {
+      value: 128,
+      message: '128文字以内で入力してください。',
+    },
+  },
+  name: {
+    required: 'user_nameを入力してください。',
+    pattern: {
+      value: /^[a-zA-Z0-9_]+$/,
+      message: '半角英数字およびアンダースコア(_)が使用できます。',
+    },
+    maxLength: {
+      value: 30,
+      message: '30文字以内で入力してください。',
+    },
+  },
+  nickname: {
+    required: 'ユーザー名を入力してください。',
+    maxLength: {
+      value: 30,
+      message: '30文字以内で入力してください。',
+    },
+  },
+}


### PR DESCRIPTION
## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes #63

## やったこと
<!-- このプルリクで何をしたのか？ -->
- サインアップページの実装
- サインアップ完了ページの実装
  - 認証メール再送機能の実装
    - 1分間のクールタイムあり
- rubocop/schema_loader を追加
  - 導入前、userモデルのuniqueバリデーションについてcopの警告が止まなかったため

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- ユーザーの新規登録

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- なし

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ユーザーの新規登録 → 認証＋サインイン

https://github.com/user-attachments/assets/d33ae77d-229d-4e01-bb7e-44e8355554d9


