### PR TITLE
refactor: ユーザー認証用メールに記載するURLを修正した

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -30,3 +30,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+config/settings.local.yml
+config/settings/*.local.yml
+config/environments/*.local.yml

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -11,6 +11,9 @@ gem 'bcrypt', '~> 3.1.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
+# [https://github.com/rubyconfig/config]
+gem 'config'
+
 # ユーザー認証を提供[https://github.com/heartcombo/devise]
 gem 'devise'
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -102,12 +102,16 @@ GEM
       logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
+    config (5.5.2)
+      deep_merge (~> 1.2, >= 1.2.1)
+      ostruct
     connection_pool (2.5.0)
     crass (1.0.6)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    deep_merge (1.2.2)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -393,6 +397,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   bullet
+  config
   debug
   devise
   devise-i18n

--- a/backend/app/controllers/api/v1/user/confirmations_controller.rb
+++ b/backend/app/controllers/api/v1/user/confirmations_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::User::ConfirmationsController < Api::V1::BaseController
+  def update
+    user = User.find_by(confirmation_token: params[:confirmation_token])
+    return render json: { message: 'User record is not found.' }, status: :not_found if user.nil?
+    return render json: { message: 'User has already been confirmed.' }, status: :bad_request if user.confirmed?
+
+    user.update!(confirmed_at: Time.current)
+
+    render json: { message: 'User confirmation succeeded.' }, status: :ok
+  end
+end

--- a/backend/app/views/devise/mailer/confirmation_instructions.erb
+++ b/backend/app/views/devise/mailer/confirmation_instructions.erb
@@ -1,0 +1,5 @@
+<p><%= t(:welcome).capitalize + ' ' + @email %>!</p>
+
+<p><%= t '.confirm_link_msg' %> </p>
+
+<p><%= link_to t('.confirm_account_link'), "#{Settings.front_domain}/confirmation?confirmation_token=#{@token}", target: :_blank, rel: 'noopener noreferrer'%></p>

--- a/backend/config/initializers/config.rb
+++ b/backend/config/initializers/config.rb
@@ -1,0 +1,68 @@
+Config.setup do |config|
+  # Name of the constant exposing loaded settings
+  config.const_name = 'Settings'
+
+  # Ability to remove elements of the array set in earlier loaded settings file. For example value: '--'.
+  #
+  # config.knockout_prefix = nil
+
+  # Overwrite an existing value when merging a `nil` value.
+  # When set to `false`, the existing value is retained after merge.
+  #
+  # config.merge_nil_values = true
+
+  # Overwrite arrays found in previously loaded settings file. When set to `false`, arrays will be merged.
+  #
+  # config.overwrite_arrays = true
+
+  # Defines current environment, affecting which settings file will be loaded.
+  # Default: `Rails.env`
+  #
+  # config.environment = ENV.fetch('ENVIRONMENT', :development)
+
+  # Load environment variables from the `ENV` object and override any settings defined in files.
+  #
+  # config.use_env = false
+
+  # Define ENV variable prefix deciding which variables to load into config.
+  #
+  # Reading variables from ENV is case-sensitive. If you define lowercase value below, ensure your ENV variables are
+  # prefixed in the same way.
+  #
+  # When not set it defaults to `config.const_name`.
+  #
+  config.env_prefix = 'SETTINGS'
+
+  # What string to use as level separator for settings loaded from ENV variables. Default value of '.' works well
+  # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where
+  # using dots in variable names might not be allowed (eg. Bash).
+  #
+  # config.env_separator = '.'
+
+  # Ability to process variables names:
+  #   * nil  - no change
+  #   * :downcase - convert to lower case
+  #
+  # config.env_converter = :downcase
+
+  # Parse numeric values as integers instead of strings.
+  #
+  # config.env_parse_values = true
+
+  # Validate presence and type of specific config values. Check https://github.com/dry-rb/dry-validation for details.
+  #
+  # config.schema do
+  #   required(:name).filled
+  #   required(:age).maybe(:int?)
+  #   required(:email).filled(format?: EMAIL_REGEX)
+  # end
+
+  # Evaluate ERB in YAML config files at load time.
+  #
+  # config.evaluate_erb_in_yaml = true
+
+  # Name of directory and file to store config keys
+  #
+  # config.file_name = 'settings'
+  # config.dir_name = 'settings'
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
         confirmations: 'api/v1/overrides/confirmations',
       }
 
+      namespace :user do
+        resource :confirmations, only: %i[update]
+      end
       namespace :current do
         resource :user, only: %i[show]
         resources :posts, only: %i[index show create update]

--- a/backend/config/settings/development.yml
+++ b/backend/config/settings/development.yml
@@ -1,0 +1,1 @@
+front_domain: http://localhost:5173

--- a/backend/config/settings/production.yml
+++ b/backend/config/settings/production.yml
@@ -1,0 +1,1 @@
+front_domain: https://api.example.com

--- a/backend/config/settings/test.yml
+++ b/backend/config/settings/test.yml
@@ -1,0 +1,1 @@
+front_domain: http://localhost:5173

--- a/backend/spec/requests/api/v1/user/confirmations_spec.rb
+++ b/backend/spec/requests/api/v1/user/confirmations_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Api::V1::User::ConfirmationsController, type: :request do
+  describe 'PATCH /api/v1/user/confirmations' do
+    let!(:user) { create(:user, confirmed_at: nil) }
+    let!(:confirmation_token) { user.confirmation_token }
+    subject { patch '/api/v1/user/confirmations', params: { confirmation_token: } }
+
+    context 'ユーザーが存在し、未認証であるとき' do
+      it 'ユーザーを認証し、レスポンス ok が返る' do
+        subject
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body['message']).to eq('User confirmation succeeded.')
+          expect(user.reload.confirmed?).to be_truthy
+        end
+      end
+    end
+
+    context 'ユーザーが存在しないとき' do
+      let!(:confirmation_token) { 'invalid_token' }
+
+      it 'レスポンス not found が返る' do
+        subject
+        aggregate_failures do
+          expect(response).to have_http_status(:not_found)
+          expect(response.parsed_body['message']).to eq('User record is not found.')
+        end
+      end
+    end
+
+    context 'ユーザーが認証済みのとき' do
+      it 'レスポンス bad request が返る' do
+        user.update!(confirmed_at: Time.current)
+        subject
+        aggregate_failures do
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body['message']).to eq('User has already been confirmed.')
+        end
+      end
+    end
+  end
+end

--- a/frontend/app/src/App.tsx
+++ b/frontend/app/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import CurrentUserFetch from './components/CurrentUserFetch'
 
 // Route
+import Confirmation from './pages/confirmation'
 import CurrentPosts from './pages/current/posts'
 import CurrentPostDetail from './pages/current/posts/[id]'
 import CurrentPostsEdit from './pages/current/posts/edit/[id]'
@@ -30,6 +31,8 @@ function App() {
       <Routes>
         {/* ホームページ */}
         <Route path="/" element={<Home />} />
+        {/* 確認ページ */}
+        <Route path="/confirmation" element={<Confirmation />} />
         {/* サインインユーザー投稿一覧 */}
         <Route path="/current/posts" element={<CurrentPosts />} />
         {/* サインインユーザー投稿詳細 */}

--- a/frontend/app/src/hooks/useConfirmAccount.ts
+++ b/frontend/app/src/hooks/useConfirmAccount.ts
@@ -1,0 +1,46 @@
+import axios, { AxiosError } from 'axios'
+import { useEffect } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useSnackbarState } from '@/hooks/useGlobalState'
+
+export const useConfirmAccount = () => {
+  const [, setSnackbarState] = useSnackbarState()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+
+  useEffect(() => {
+    const token = searchParams.get('confirmation_token')
+
+    if (!token) {
+      setSnackbarState({
+        message: '不正なアクセスです',
+        severity: 'error',
+        pathname: '/posts',
+      })
+      navigate('/posts')
+      return
+    }
+
+    const url = `${import.meta.env.VITE_API_BASE_URL}/user/confirmations`
+
+    axios
+      .patch(url, Object.fromEntries(searchParams.entries()))
+      .then(() => {
+        setSnackbarState({
+          message: '認証に成功しました',
+          severity: 'success',
+          pathname: '/sign_in',
+        })
+        navigate('/sign_in')
+      })
+      .catch((e: AxiosError<{ e: string }>) => {
+        console.error(e.message)
+        setSnackbarState({
+          message: '不正なアクセスです',
+          severity: 'error',
+          pathname: '/posts',
+        })
+        navigate('/posts')
+      })
+  }, [searchParams, navigate, setSnackbarState])
+}

--- a/frontend/app/src/pages/confirmation.tsx
+++ b/frontend/app/src/pages/confirmation.tsx
@@ -1,0 +1,8 @@
+import { useConfirmAccount } from '@/hooks/useConfirmAccount'
+
+const Confirmation = () => {
+  useConfirmAccount()
+  return null
+}
+
+export default Confirmation


### PR DESCRIPTION
## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes #66

## やったこと
<!-- このプルリクで何をしたのか？ -->
- 認証用URLの修正
  - バックエンド `localhost:3000` → フロントエンド `localhost:5173`
- Gem(config) を導入

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- なし

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
#### 認証メールに記載されたURL（画面左下）
- 修正前
 
![Screenshot 2025-04-15 15 45 06](https://github.com/user-attachments/assets/40626f62-5afc-406c-bfed-dba0fe1806ac)

- 修正後
![Screenshot 2025-04-15 15 43 44](https://github.com/user-attachments/assets/b5dfe6ee-829c-4241-ab35-6461ae5390f5)
