### PR TITLE
fix: BaseControllerのalias_methodを削除し、DeviseTokenAuthヘルパーを安全に参照するメソッド定…

### DIFF
--- a/backend/app/controllers/api/v1/base_controller.rb
+++ b/backend/app/controllers/api/v1/base_controller.rb
@@ -1,5 +1,13 @@
 class Api::V1::BaseController < ApplicationController
-  alias_method :current_user, :current_api_v1_user
-  alias_method :authenticate_user!, :authenticate_api_v1_user!
-  alias_method :user_signed_in?, :api_v1_user_signed_in?
+  def current_user
+    respond_to?(:current_api_v1_user) ? current_api_v1_user : nil
+  end
+
+  def authenticate_user!
+    respond_to?(:authenticate_api_v1_user!) ? authenticate_api_v1_user! : head(:unauthorized)
+  end
+
+  def user_signed_in?
+    respond_to?(:api_v1_user_signed_in?) ? api_v1_user_signed_in? : false
+  end
 end


### PR DESCRIPTION
…義に変更した

## 今回対応した issue
<!-- #の後に続けてissue番号を追記すること。 -->
- closes # 

## やったこと
<!-- このプルリクで何をしたのか？ -->
- BaseControllerのalias_methodを削除し、単なるメソッドとして定義した
  - auth配下以外でもBaseControllerを継承しているため

## 残りの作業
<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->
- なし

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 変更前、SpecテストでNameErrorが出ることがあった
  - ファイル読み込み順次第で通ったり通らなかったりしていたっぽい

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- なし